### PR TITLE
Searchengine: Mojeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 * [Whoogle Search](https://github.com/benbusby/whoogle-search) - A self-hosted, ad-free, privacy-respecting Google metasearch engine.
 * [Qwant](https://www.qwant.com/) - A privacy oriented search engine made in France with no tracking.
 * [SearX](https://searx.me/) - Privacy-respecting metasearch engine.
+* [Mojeek](https://mojeek.com) - Independent and unbiased search results with no user tracking in UK's greenest data centre.
 
 ## Photo storage
 <img width="16" src="misc/forbidden.png"> </img> **AVOID**


### PR DESCRIPTION
Mojeek is an independent (with its own crawlers, as opposed to DDG, Qwant, ... that rely on Bing and others)search engine from the UK which does not track at all and is therefore privacy respecting.