### PR TITLE
Replace KeepassDX with KeepassXC

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ Remember: Without strong encryption, you will be spied on systematically by lots
 
 <img width="16" src="misc/check.png"> </img>  **Instead use:**
 * [Bitwarden](https://bitwarden.com) - An open source cloud based password manager
-* [KeepassDX](https://www.keepassdx.com/)
+* [KeepassXC](https://keepassxc.org/) - Securely store passwords using industry standard encryption, no sync just storage.
+  * [KeepassDX](https://www.keepassdx.com/) for Android.
+  * [Strongbox](https://strongboxsafe.com/) for iOS.
+  * [KeeWeb](https://keeweb.info/) for Web and other platforms.
 
 ## Video Conferencing
 <img width="16" src="misc/forbidden.png"> </img> **AVOID**:


### PR DESCRIPTION
KeepassDX is only an Android client. I replaced it with KeepassXC which is available for many (desktop) platforms and also added sub-sections for clients on other platforms (including KeepassDX for Android).