### PR TITLE
Fix Heading of «Streaming Platforms (Twitch)»

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   * [Youtube](#youtube)
   * [Twitter](#twitter)
   * [Reddit](#reddit)
-  * [Streaming Platforms (Twitch)](#streaming-platforms)
+  * [Streaming Platforms (Twitch)](#streaming-platforms-twitch)
 * [Teamworking and Communication Tools](#teamworking-tools)
 * [Instant Messaging](#instant-messaging)
 * [Password Managers](#password-managers)


### PR DESCRIPTION
Commit 587c27ad06281b40e1cdee4e161c15b8bf7bc7fa changed the heading from «Streaming Platforms» to «Streaming Platforms (Twitch)». Updated the link accordingly.