### PR TITLE
Add vaultwarden

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 
 <img width="16" src="misc/check.png"> </img>  **Instead use:**
 * [Bitwarden](https://bitwarden.com) - An open source cloud based password manager
+  * [vaultwarden](https://github.com/dani-garcia/vaultwarden/) - Unofficial Bitwarden compatible self-hosted server, formerly known as bitwarden_rs.
 * [KeepassXC](https://keepassxc.org/) - Securely store passwords using industry standard encryption, no sync just storage.
   * [KeepassDX](https://www.keepassdx.com/) for Android.
   * [Strongbox](https://strongboxsafe.com/) for iOS.
@@ -510,4 +511,3 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 * [Skymap](https://skymaponline.net/) - Open online planetarium program.
 * [CrowdSec](https://github.com/crowdsecurity/crowdsec) - An open-source, modernized and collaborative fail2ban
 * [Hetty](https://github.com/dstotijn/hetty) - Hetty is an HTTP toolkit for security research. It aims to be an open-source alternative to Burp Suite Pro.
-


### PR DESCRIPTION
If the users don't trust the official Bitwarden server, they can self-host their own but a lighter weight version, albeit unofficial.