### PR TITLE
Add DuckDuckGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [Whoogle Search](https://github.com/benbusby/whoogle-search) - A self-hosted, ad-free, privacy-respecting Google metasearch engine.
 - [Qwant](https://www.qwant.com/) - A privacy oriented search engine made in France with no tracking.
 - [SearX](https://searx.me/) - Privacy-respecting metasearch engine.
+- [DuckDuckGo](https://duckduckgo.com) - A privacy respecting search engine
 
 ## Web Browser
 


### PR DESCRIPTION
Add DuckDuckGo as a privacy respecting search engine.