### PR TITLE
Change Paperless to Paperless-ng as Paperless is now archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Remember: Without strong encryption, you will be spied on systematically by lots
 - [QRcp](https://github.com/claudiodangelis/qrcp) - Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
 - [Snapdrop](https://snapdrop.net/) - A Progressive Web App for local file sharing inspired by Apple's Airdrop.
 - [Paperless-ng](https://github.com/jonaswinkler/paperless-ng) - A supercharged version of paperless: scan, index and archive all your physical documents.
+  - [Paperless](https://github.com/the-paperless-project/paperless) - [Now archived] Scan, index, and archive all of your paper documents.
 
 ## Maps and Navigation
 <img width="16" src="misc/forbidden.png"> </img> **Avoid**

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Remember: Without strong encryption, you will be spied on systematically by lots
 - [Dat-cp](https://github.com/tom-james-watson/dat-cp) - Copy files between hosts on a network using the peer-to-peer Dat network.
 - [QRcp](https://github.com/claudiodangelis/qrcp) - Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
 - [Snapdrop](https://snapdrop.net/) - A Progressive Web App for local file sharing inspired by Apple's Airdrop.
-- [Paperless](https://github.com/the-paperless-project/paperless) - Scan, index, and archive all of your paper documents.
+- [Paperless-ng](https://github.com/jonaswinkler/paperless-ng) - A supercharged version of paperless: scan, index and archive all your physical documents.
 
 ## Maps and Navigation
 <img width="16" src="misc/forbidden.png"> </img> **Avoid**


### PR DESCRIPTION
After 5 years since it's inception, Daniel Quinn [archived the repository](https://github.com/the-paperless-project/paperless) as he couldn't maintain it anymore. In the meantime, Jonas Winkler, forked it as [Paperless-ng](https://github.com/jonaswinkler/paperless-ng), reworking it, improving the UI and, in general, supercharging the already excelent project.

This pull request aims to replace the Paperless repository link to the Paperless-ng respository link, as it currently maintained and constantly updated. However, as the original Paperless is not deprecated (only archived) a link to the original repository is still added with a notice of archival.