### PR TITLE
Adding PIVX SHIELD coin and pivx2bitcoin private crypto swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 
 <img width="16" src="misc/check.png"> </img>  **Instead use**
 - [Monero](https://www.getmonero.org/) - Monero is cash for a connected world. It's fast, private, untraceable and secure.
+- [Pivx Shield](https://www.pivx.org/) - Proof-of-Stake coin, with SHIELD transactions, gives users private, anonymous, nearly instant payments. 
 - Cash - Use person-to-person payments using physical notes and coins.
 
 **USE WITH CAUTION**

--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 
 <img width="16" src="misc/check.png"> </img> Instead use Rotki, an awesome, feature-rich and open source app:
 - [Rotki](https://github.com/rotki/rotki) - An awesome portfolio tracking, analytics, accounting and tax reporting application that protects your privacy.
+- [pivx2bitcoin](https://pivx2bitcoin.com) - Awesome private crypto swap. No accounts, no signups, no JavaScript, no tracking, no analytics. Tor and VPN friendly, too.
 
 ## Databases
 <img width="16" src="misc/forbidden.png"> </img> Avoid using privative databases which you don't control such as Google Firebase.


### PR DESCRIPTION
This PR adds a link to the PIVX cryptocurrency, which features SHIELD transactions. A Proof-of-Stake coin that, when using SHIELD, provides anonymity on sender, receiver, and amount of transactions. 

Also adds pivx2bitcoin. An anonymous crypto swap with no accounts, no JavaScript, and no tracking. Hosted on Tor as well as clearnet, and VPN friendly.