### PR TITLE
Tweak Brave description and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 - [Ungoogled Chromium](https://ungoogled-software.github.io/)
 - [Tor Browser](https://www.torproject.org/)
 
-> Controversial but good for privacy and protection against browser fingerprinting: [Brave](https://brave.com/) - Android/iOS. [Read more info on this related discussion](https://libredd.it/r/privacytoolsIO/comments/gytwmd/brave_browser_privacytoolsio_and_the_negativity/) and [the Wikipedia page](https://en.wikipedia.org/wiki/Brave_(web_browser)#Controversies).
+> Controversial but good for privacy and protection against browser fingerprinting: [Brave](https://brave.com/) - Android/iOS/Desktop. [Read more info on this related discussion](https://libredd.it/r/privacytoolsIO/comments/gytwmd/brave_browser_privacytoolsio_and_the_negativity/) and [the Wikipedia page](https://en.wikipedia.org/wiki/Brave_(web_browser)#Controversies).
 
 ### Browser Sync
 - [xBrowserSync](https://www.xbrowsersync.org/) - Browser syncing as it should be: secure, anonymous and free!

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 - [Ungoogled Chromium](https://ungoogled-software.github.io/)
 - [Tor Browser](https://www.torproject.org/)
 
-> Controversial option: [Brave](https://brave.com/) - Android/iOS. [Read more info on this related discussion](https://libredd.it/r/privacytoolsIO/comments/gytwmd/brave_browser_privacytoolsio_and_the_negativity/) and [this blog post](https://aspenuwu.me/blog/dont-use-brave/).
+> Controversial but good option: [Brave](https://brave.com/) - Android/iOS. [Read more info on this related discussion](https://libredd.it/r/privacytoolsIO/comments/gytwmd/brave_browser_privacytoolsio_and_the_negativity/) and [the Wikipedia page](https://en.wikipedia.org/wiki/Brave_(web_browser)#Controversies).
 
 ### Browser Sync
 - [xBrowserSync](https://www.xbrowsersync.org/) - Browser syncing as it should be: secure, anonymous and free!

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 - [Ungoogled Chromium](https://ungoogled-software.github.io/)
 - [Tor Browser](https://www.torproject.org/)
 
-> Controversial but good option: [Brave](https://brave.com/) - Android/iOS. [Read more info on this related discussion](https://libredd.it/r/privacytoolsIO/comments/gytwmd/brave_browser_privacytoolsio_and_the_negativity/) and [the Wikipedia page](https://en.wikipedia.org/wiki/Brave_(web_browser)#Controversies).
+> Controversial but good for privacy and protection against browser fingerprinting: [Brave](https://brave.com/) - Android/iOS. [Read more info on this related discussion](https://libredd.it/r/privacytoolsIO/comments/gytwmd/brave_browser_privacytoolsio_and_the_negativity/) and [the Wikipedia page](https://en.wikipedia.org/wiki/Brave_(web_browser)#Controversies).
 
 ### Browser Sync
 - [xBrowserSync](https://www.xbrowsersync.org/) - Browser syncing as it should be: secure, anonymous and free!


### PR DESCRIPTION
I have edited the description of Brave a little, and also removed the link to [this blog post](https://aspenuwu.me/blog/dont-use-brave/), as it only gives one side of the controversies, and it frankly seems more like an opinionated rant than an actual discussion. I have replaced it with the Controversies section of the Brave Wikipedia page, which has a much better and more professional position on it. 