### PR TITLE
Add space to Pocket Paint name

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@
 - [DigiKam](https://www.digikam.org/) - Awesome Professional Photo Management with the Power of Open Source.
 
 #### Android
-- [PocketPaint](https://github.com/Catrobat/Paintroid) - The standard image manipulation app for Catroid.
+- [Pocket Paint](https://github.com/Catrobat/Paintroid) - The standard image manipulation app for Catroid.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Remove Exif data from pictures before sharing them.
 - [ImagePipe](https://codeberg.org/Starfish/Imagepipe) - Reduces image size and removes exif-tags when sharing images on android devices.
 


### PR DESCRIPTION
F-Droid doesn't find it when searching for "pocketpaint", the official name is "pocket paint".