### PR TITLE
Fix "TranslateLocally" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Remember: Without strong encryption, you will be spied on systematically by lots
 - [Libretranslate](https://libretranslate.com/) - Open Source Machine Translation - 100% Self-Hosted. No Limits. No Ties to Proprietary Services.
 - [Apertium](https://apertium.org/) - A free/open-source machine translation platform, runs offline on your computer
 - [Softcatala](https://www.softcatala.org/traductor/) - Open Source Translation tool - Only Catalan/Spanish/English/French (uses apertium)
-- [TranslateLocally](translatelocally.com/) – Free/open-source neural MT, runs offline on your computer
+- [TranslateLocally](https://translatelocally.com/) – Free/open-source neural MT, runs offline on your computer
 
 <img width="16" src="misc/check.png"> </img> **Alternative Google Translate frontends**
 - [Lingva](https://github.com/TheDavidDelta/lingva-translate) - Alternative front-end for Google Translate. [Demo](https://lingva.ml/).


### PR DESCRIPTION
The link is missing the protocol, which results in the browser trying to access `https://github.com/pluja/awesome-privacy/blob/main/translatelocally.com`.