### PR TITLE
Add Budget Zen

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [Nextcloud Cospend](https://apps.nextcloud.com/apps/cospend) - A group/shared budget manager inspired by the great IHateMoney.
    - [MoneyBuster](https://gitlab.com/eneiluj/moneybuster/) - Android client for Nextcloud Cospend and [IHateMoney](https://ihatemoney.org/) servers.
 - [GnuCash](https://gnucash.org/) - GnuCash is personal and small-business financial-accounting software, freely licensed under the GNU GPL and available for GNU/Linux, BSD, Solaris, Mac OS X and Microsoft Windows.
+- [Budget Zen](https://budgetzen.net) - Simple and Encrypted Budget Management.
 
 ### CRYPTO
 <img width="16" src="misc/forbidden.png"> </img> Avoid using any exchange portfolio tracking or any app like Blockfolio as they **do not** respect your privacy in any way.


### PR DESCRIPTION
Budget Zen 2.0 is end-to-end encrypted via [userbase](https://userbase.com). You can read more about [that announcement here](https://news.onbrn.com/announcing-budget-zen-2.0-end-to-end-encrypted).

While it isn't technically Open Source (unlicensed), its source is available and I just provide licenses on a request basis.

The website also has simple, privacy-respecting analytics (not user tracking) via [Fathom](https://usefathom.com).