### PR TITLE
Added Kizie in Twitter section

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ With email aliases, you can finally create a different identity for each website
 - [Nitter](https://github.com/zedeus/nitter/wiki/Instances) - Nitter is a free and open source alternative Twitter front-end focused on privacy.
 	- [Fritter](https://github.com/jonjomckay/fritter/) - A free, open-source Nitter client for Android and iOS.
 - [Feetter](https://github.com/pluja/Feetter) - Create, sync and manage Nitter feeds without registration from any device.
+- [Kizie](https://kizie.co) - Cleaner, better and privacy focussed Twitter client for Web.
 
 ### Reddit
 <img width="16" src="misc/forbidden.png"> </img> Try to avoid using Reddit or at least avoid their official clients as they are plenty of trackers, ads and share unnecessary user data with their servers.


### PR DESCRIPTION
Resolved conflicts from https://github.com/pluja/awesome-privacy/pull/168, cc: @pluja 

Here's why Kizie is privacy focussed:

- Kizie only uses Pirsch for analytics(🖤 Pirsch)
- No ads anywhere on the site or third-party service except Stripe and Sentry, so no pixel peeking from any service
- None of user's data is collected except for bare minimum to make the app work
- Protected profiles/tweets are respected and shown only to intended users