### PR TITLE
Fix Capitalization Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 ### Third party owned
 - [ProtonMail](https://protonmail.com/) - Secure Email. Based in Switzerland. [Read this article over Climate activist arrest](https://protonmail.com/blog/climate-activist-arrest/).
 - [Tutanota](https://tutanota.com/) - Secure email for everybody. Open Source.
-- [RiseUp](https://riseup.net/en/about-us) - Online communication tools for people and groups working on liberatory social change.
+- [Riseup](https://riseup.net/en/about-us) - Online communication tools for people and groups working on liberatory social change.
 
 ### Self hosted
 - [Mail-in-a-box](https://github.com/mail-in-a-box/mailinabox) - Mail-in-a-Box helps individuals take back control of their email by defining a one-click, easy-to-deploy SMTP+everything else server: a mail server in a box.
@@ -378,8 +378,8 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 
 With email aliases, you can finally create a different identity for each website. Defend against spams, phishing and data breach. You can choose self-hosting any of the following options or you can also use their own platform as a service.
 
-- [Simplelogin](https://github.com/simple-login/app)
-- [Anonaddy](https://github.com/anonaddy/anonaddy)
+- [SimpleLogin](https://github.com/simple-login/app)
+- [AnonAddy](https://github.com/anonaddy/anonaddy)
 
 ## Maps and Navigation
 <img width="16" src="misc/forbidden.png"> </img> **Avoid**


### PR DESCRIPTION
It's [AnonAddy](https://github.com/anonaddy) not Anonaddy, it's [SimpleLogin](https://github.com/simplelogin) not Simplelogin, and it's [Riseup](https://github.com/riseupnet) not RiseUp.