### PR TITLE
Fix tags mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - [Notes and Tasks](#notes-and-tasks)
 - [Office](#office)
 - [Operating Systems](#operating-systems)
-    - [Android](#android-1)
+    - [Android](#android)
     - [PC / MacOS](#pc--macos)
     - [Smart TV](#smart-tv)
 - [Password Managers](#password-managers)


### PR DESCRIPTION
The tag on "Operative systems > Android" redirects to "Photo Editing and Management", so this fixes that