### PR TITLE
Remove mention of iOS from Fritter

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ With email aliases, you can finally create a different identity for each website
 
 <img width="16" src="misc/check.png"> </img> **Alternative Twitter Frontends:**
 - [Nitter](https://github.com/zedeus/nitter/wiki/Instances) - Nitter is a free and open source alternative Twitter front-end focused on privacy.
-	- [Fritter](https://github.com/jonjomckay/fritter/) - A free, open-source Nitter client for Android and iOS.
+	- [Fritter](https://github.com/jonjomckay/fritter/) - A free, open-source Nitter client for Android.
 - [Feetter](https://github.com/pluja/Feetter) - Create, sync and manage Nitter feeds without registration from any device.
 - [Kizie](https://kizie.co) - Cleaner, better and privacy focussed Twitter client for Web.
 


### PR DESCRIPTION
There is no iOS client for Fritter as seen on https://fritter.cc/ or https://github.com/jonjomckay/fritter

(Which is quite unfortunate as I was looking for an iOS app front-end for Twitter...)