### PR TITLE
Fix SimplyTranslate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 <img width="16" src="misc/check.png"> </img> **Alternative Google Translate frontends**
 - [Lingva](https://github.com/TheDavidDelta/lingva-translate) - Alternative front-end for Google Translate. [Demo](https://lingva.ml/).
-- [Simplytranslate](https://git.sr.ht/~metalune/simplytranslate_web) - Alternative front-end for Google Translate and LibreTranslate. [Demo](https://translate.metalune.xyz/)
+- [Simplytranslate](https://git.sr.ht/~metalune/simplytranslate_web) - Alternative front-end for Google Translate and LibreTranslate. [Demo](https://simplytranslate.org/)
 
 ## Uncategorized
 - [Skymap](https://skymaponline.net/) - Open online planetarium program.


### PR DESCRIPTION
https://translate.metalune.xyz/ has been deprecated

![image](https://user-images.githubusercontent.com/100167438/156613671-5ccb41db-ee13-4e5b-a69f-34457706508b.png)