### PR TITLE
Added Spotify clients for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ With email aliases, you can finally create a different identity for each website
 - [Spot](https://github.com/xou816/spot) - Native Spotify client built in GTK and Rust.
 - [psst](https://github.com/jpochyla/psst) - Fast and multi-platform Spotify client with native GUI.
 - [ncspot](https://github.com/hrkfdn/ncspot) - Cross-platform ncurses Spotify client written in Rust, inspired by ncmpc and the likes.
+- <img width="16" src="misc/android.png"> [blade player](https://github.com/vhaudiquet/BladePlayer) - Open source Android Spotify client, works without premium. Although they say u need premium.
+- <img width="16" src="misc/android.png"> [xManager](https://github.com/xManager-v2/xManager-Spotify) - Open source Spotify manager. Builds Spotify app with additional features.
 
 **Youtube Music alternative clients**
 - [Beatbump](https://github.com/snuffyDev/Beatbump) - Alternative frontend for YouTube Music; no ads and custom API wrapper.

--- a/README.md
+++ b/README.md
@@ -491,7 +491,10 @@ With email aliases, you can finally create a different identity for each website
 - [Spot](https://github.com/xou816/spot) - Native Spotify client built in GTK and Rust.
 - [psst](https://github.com/jpochyla/psst) - Fast and multi-platform Spotify client with native GUI.
 - [ncspot](https://github.com/hrkfdn/ncspot) - Cross-platform ncurses Spotify client written in Rust, inspired by ncmpc and the likes.
-- <img width="16" src="misc/android.png"> [blade player](https://github.com/vhaudiquet/BladePlayer) - Open source Android Spotify client, works without premium. Although they say u need premium.
+
+\* No premium required.
+- <img width="16" src="misc/android.png"> [Blade Player](https://github.com/vhaudiquet/BladePlayer) - Open source Spotify client, works without premium.
+ Although they say u need premium.
 - <img width="16" src="misc/android.png"> [xManager](https://github.com/xManager-v2/xManager-Spotify) - Open source Spotify manager. Builds Spotify app with additional features.
 
 **Youtube Music alternative clients**

--- a/README.md
+++ b/README.md
@@ -496,9 +496,9 @@ With email aliases, you can finally create a different identity for each website
 
 
 \* No premium required.
+
 - <img width="16" src="misc/android.png"> [Blade Player](https://github.com/vhaudiquet/BladePlayer) - Open source Spotify client, works without premium.
- Although they say u need premium.
-- <img width="16" src="misc/android.png"> [xManager](https://github.com/xManager-v2/xManager-Spotify) - Open source Spotify manager. Builds Spotify app with additional features.
+
 
 **Youtube Music alternative clients**
 - [Beatbump](https://github.com/snuffyDev/Beatbump) - Alternative frontend for YouTube Music; no ads and custom API wrapper.


### PR DESCRIPTION
Addtional spotify clients for Android.

xManager: lets you build spotify with additonal features like black Amoled background and ad blocking (Warning this manager has ads which can be turned off) https://github.com/xManager-v2/xManager-Spotify

Blade Player: Open source Spotify client which actually works without Premium. Although they say premium is needed.
missing some features that normal Spotify have. https://github.com/vhaudiquet/BladePlayer