### PR TITLE
Add Passky

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ With email aliases, you can finally create a different identity for each website
   - [Strongbox](https://strongboxsafe.com/) for iOS.
   - [KeeWeb](https://keeweb.info/) for Web and other platforms.
 - [Padloc](https://padloc.app/) - The last password manager you'll ever want to use.
+- [Passky](https://passky.org) - Simple, modern, lightweight, open-source and secure password manager.
 
 ## Payments
 <img width="16" src="misc/forbidden.png"> </img> **Avoid**


### PR DESCRIPTION
Passky is simple, lightweight, easy to use and open source passowrd manager.

It's one of the easiest cloud-based password manage to self-host.