### PR TITLE
Add LessPass to Password manager's section

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,10 +613,6 @@ With email aliases, you can finally create a different identity for each website
 - [Padloc](https://padloc.app/) - The last password manager you'll ever want to use.
 - [Passky](https://passky.org) - Simple, modern, lightweight, open-source and secure password manager.
 - [LessPass](https://www.lesspass.com) - Stateless password manager. Remember one master password to access your passwords. No sync needed.
-  - [LessPass App](https://play.google.com/store/apps/details?id=com.lesspass.android) for Android.
-  - [LessPass App](https://apps.apple.com/us/app/lesspass/id1531215924) for iOS.
-  - [LessPass Extension](https://addons.mozilla.org/en-US/firefox/addon/lesspass/) for Firefox.
-  - [LessPass Extension](https://chrome.google.com/webstore/detail/lesspass/lcmbpoclaodbgkbjafnkbbinogcbnjih) for Chrome/Chromium.
 
 ## Payments
 <img width="16" src="misc/forbidden.png"> </img> **Avoid**

--- a/README.md
+++ b/README.md
@@ -612,6 +612,11 @@ With email aliases, you can finally create a different identity for each website
   - [KeeWeb](https://keeweb.info/) for Web and other platforms.
 - [Padloc](https://padloc.app/) - The last password manager you'll ever want to use.
 - [Passky](https://passky.org) - Simple, modern, lightweight, open-source and secure password manager.
+- [LessPass](https://www.lesspass.com) - Stateless password manager. Remember one master password to access your passwords. No sync needed.
+  - [LessPass App](https://play.google.com/store/apps/details?id=com.lesspass.android) for Android.
+  - [LessPass App](https://apps.apple.com/us/app/lesspass/id1531215924) for iOS.
+  - [LessPass Extension](https://addons.mozilla.org/en-US/firefox/addon/lesspass/) for Firefox.
+  - [LessPass Extension](https://chrome.google.com/webstore/detail/lesspass/lcmbpoclaodbgkbjafnkbbinogcbnjih) for Chrome/Chromium.
 
 ## Payments
 <img width="16" src="misc/forbidden.png"> </img> **Avoid**


### PR DESCRIPTION
First of all, thanks @pluja for creating this awesome curated list :raised_hands: 

I'm suggesting you to add [LessPass](https://www.lesspass.com) to the FOSS list on the Password manager's section. I'm not related in any way with LessPass, I've just been using it for years, and I love it! 

If you haven't tried yet, I'm suggesting you to do it :wink: 

## How it works
To create a password you'll provide:
- Domain of the website you are loging in
- Username or email you are using
- A master password (the only password you actually need to remember)
- Several customizable options such as length o which characters include/exclude

This will create a password that you can use for the domain & user you specified. The awesome thing of LessPass is that **is not storing it anywhere**. Next time you want to login in the same website, you just enter the EXACT SAME inputs as before (one little change and the output password will be completely different, which is it's sole disadvantage).

## My personal suggestions
- Don't use subdomains (use google.com instead of account.google.com or mail.google.com)
- Always use the same options (length and included characters)

I hope you like my contribution.

Kind regards,
Dani