### PR TITLE
Add blindsend to File Management and Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Remember: Without strong encryption, you will be spied on systematically by lots
   - [Paperless](https://github.com/the-paperless-project/paperless) - [Now archived] Scan, index, and archive all of your paper documents.
 - [OnionShare](https://github.com/micahflee/onionshare) - An open source tool that lets you securely and anonymously share files, host websites, and chat with friends using the Tor network.
 - [Sharik](https://github.com/marchellodev/sharik) - Sharik works with Wi-Fi connection or Tethering (Wi-Fi Hotspot). No internet connection needed. Available for Android, iOS, Linux, MacOS & Windows.
+- [Blindsend](https://github.com/blindnet-io/blindsend) - Open source tool for private, end-to-end encrypted file exchange.
 
 ## Fitness and Health
 <img width="16" src="misc/forbidden.png"> </img> Your health is a **very** important piece of your **private data** and you should care **a lot** about it. Also, health related data is among the most coveted. Please don't use apps from Google, Fitbit, Huawei, Xiaomi or any company that seeks the gathering of your personal data.


### PR DESCRIPTION
Hi, I'd like to suggest a tool we made at [blindnet](https://blindnet.io) to be added to the list. 

### Blindsend
<!--- Replace what's between "<" and ">" --->
* [Blindsend](https://github.com/blindnet-io/blindsend) - Open source tool for private, end-to-end encrypted file exchange.
* **License**: MIT Licence
* **Why do you think this helps users privacy?**: Many users still use e-mail or non-encrypted file-transfer services to exchange sensitive (and often confidential) files. Even professionals (lawyers, doctors) request personal and sensitive data from their clients to be sent by e-mail. Blindsend encrypts files in the browser, before they reach the internet. It is easy to use, even for non-technical users. The parties exchanging files can remain anonimous.
* **Under what section should this service be listed?**: File Management and Sharing
* **Additional comments / info**: In the EU, thanks to the [Article 32 of GDPR](https://gdpr-info.eu/art-32-gdpr/) it is illegal for professionals (such as lawyers, doctors, etc.) to request sensitive personal information to be sent to them in non-secure ways (such as e-mail). In France, failure to comply with this obligation can get professionals fined up to 300.000 EUR and 5 years of jail time, see [Art. 226-17 of French Criminal law](https://www.cnil.fr/fr/les-sanctions-penales).

So it is very important for professionals in EU to move away from e-mail and wetransfer, and adopt services listed here. Blindsend is our contribution to making a step in the right direction.
<!--- If you want to list more than one service on this same issue, use the same format as above for each service. --->