### PR TITLE
rm firedm

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ Apps such as Tinder collect and sell your personal intimate information. Tinder 
 - [Persepolis Download Manager](https://github.com/persepolisdm/persepolis) - Persepolis is a download manager & a GUI for Aria2. It's written in Python. Persepolis is a sample of free and open source software. It's developed for GNU/Linux distributions, BSDs, MacOS, and Microsoft Windows.
 - [uGet Download Manager](https://ugetdm.com/) - uGet is a lightweight yet powerful Open Source download manager for GNU/Linux developed with GTK+, which also comes packaged as a portable Windows app. It is also available for Android.
 - [Motrix](https://github.com/agalwood/Motrix) - A full-featured download manager.
-- [FireDM](https://github.com/firedm/FireDM) - FireDM is a python open source (Internet Download Manager) with multi-connections, high speed engine, it downloads general files and videos from youtube and tons of other streaming websites. It is availabe for Linux & Windows.
 - [Xtreme Download Manager](https://github.com/subhra74/xdm) - Xtreme Download Manager (XDM) is a powerful tool to increase download speeds up to 500%, save streaming videos from YouTube, DailyMotion, Facebook, Vimeo, Google Video and 1000+ other websites, resume broken/dead downloads, schedule and convert downloads.
 - [axel](https://github.com/axel-download-accelerator/axel) - Lightweight CLI download accelerator. It supports HTTP, HTTPS, FTP and FTPS protocols.
 


### PR DESCRIPTION
Hey @pluja 

FireDM seems to be gone: https://github.com/firedm/FireDM. The org is empty: https://github.com/firedm. I couldn't find any moved repo on GH. This PR removes the entry.

Cheers,
Peter