### PR TITLE
"Remove coming soon"-note for Berty

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,9 +441,9 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 - [Tox](https://tox.chat/) - Tox is easy-to-use software that connects you with friends and family without anyone else listening in.
 - [Briar](https://briarproject.org/) - Peer-to-peer encrypted messaging and forums.
 - [Tinfoil Chat](https://github.com/maqp/tfc) - Onion-routed, endpoint secure messaging system.
+- [Berty](https://berty.tech/) - The privacy-first messaging app that works with or without internet access, cellular data or trust in the network.
 
 #### Worth mentioning
-- [Berty](https://berty.tech/) - Not released yet. The privacy-first messaging app that works with or without internet access, cellular data or trust in the network.
 - [Telegram](https://telegram.org/) - Not fully open source. No E2E encryption by default on chats.
 
 ## Link Shorteners


### PR DESCRIPTION
Hey @pluja 

I've removed the "coming soon" note on Berty - it's available now. 

I was also wondering if Telegram is actually to recommend. The background story doesn't check out IMHO, rolling it's own encryption and the risk of political involvement (Russian ownership) is high. Let me know if you want me to remove it.

Cheers,
Peter