### PR TITLE
Add privacy tools to Bitcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,9 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - Cash - Use person-to-person payments using physical notes and coins.
 
 **USE WITH CAUTION**
-- [Bitcoin](https://bitcoin.org) - Bitcoin is not anonymous nor private. Bitcoin is traceable, transparent and pseudonymous. You need to be really careful when using Bitcoin so you don't leave any traces that can later be used against you to harm your privacy. [See aantonop's video](https://yewtu.be/watch?v=JN1Bowgcle8).
+- [Bitcoin](https://bitcoin.org) - Bitcoin is not anonymous nor private. Bitcoin is traceable, transparent and pseudonymous. For a basic introduction, [see aantonop's video](https://yewtu.be/watch?v=JN1Bowgcle8). More advanced users can watch this [Bitcoin privacy series](https://yewtu.be/watch?v=QEnL5k0R08w).
+    - [Samourai Wallet](https://www.samouraiwallet.com/) - An open source, privacy-focused Bitcoin wallet available on Android. 
+    - [Sparrow Wallet](https://www.sparrowwallet.com/) - An open source, cross-platform desktop wallet that gives you many of the privacy-preserving spending tools available in Samourai Wallet.
 
 ## Personal Finances
 ### FIAT


### PR DESCRIPTION
The sentence:
> You need to be really careful when using Bitcoin so you don't leave any traces that can later be used against you to harm your privacy.

Is not actionable and does not provide the user with any information on _how_ they can use Bitcoin without leaving traces, so it was removed.

This commit provides two FOSS options, one for Android, and one for desktop, to allow Bitcoin to be used in a more private manner.