### PR TITLE
Added Qwant to the list of Search Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
   - [SearxNG](https://github.com/searxng/searxng) - Free internet metasearch engine which aggregates results from various search services and databases.  
 - [DuckDuckGo](https://duckduckgo.com) - A privacy respecting search engine.
 - [Brave Search](https://search.brave.com) - A privacy respecting search engine with [its own independent index](https://brave.com/search-independence/).
+- [Qwant](https://www.qwant.com/) - A zero tracking search engine made and hosted in France, EU.
 
 ## Social Networks and Platforms
 


### PR DESCRIPTION
Qwant is a privacy oriented search engine made in France, so it complies with European Laws, which are more restrictive in privacy regulations. More info: [https://about.qwant.com/en/search/](url)