### PR TITLE
fix: removed Skiff (since defunct and shutting down in 6 months)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,6 @@ Google captchas use cookies to track users and rank their IPs.
 - [Peergos](https://peergos.org/) - Secure and private space online where you can store, share and view your photos, videos, music and documents. Also includes a calendar, news feed, task lists, chat and email client. Open source and self-hostable.
 - [Proton Drive](https://proton.me/drive) - End-to-end encrypted Swiss vault for your files that protects your data. [Read this article over Climate activist arrest](https://protonmail.com/blog/climate-activist-arrest/).
 - [PrivateStorage](https://private.storage/) - Accountless, privacy-focused cloud storage and folder synchronization with client-side encryption.
-- [Skiff Drive](https://skiff.com/drive) - Skiff Drive protects your dataq with end-to-end encryption.
 
 **Other useful tools**
 - [Cryptomator](https://cryptomator.org) - Cryptomator encrypts your data quickly and easily. Afterwards you upload them protected to your favorite cloud service
@@ -647,7 +646,6 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 - [Tutanota](https://tutanota.com/) - Secure email for everybody. Open Source.
 - [Riseup](https://riseup.net/en/about-us) - Online communication tools for people and groups working on liberatory social change.
 - [Mailfence](https://mailfence.com) - Secure and private email.
-- [Skiff](https://skiff.com) - Privacy-first, end-to-end encrypted, open-source email.
 
 ### Self-Hosted
 - [Docker mail server](https://github.com/docker-mailserver/docker-mailserver) - A fullstack but simple mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.) using Docker.
@@ -812,7 +810,6 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [OnlyOffice](https://www.onlyoffice.com/) - Free and open source online office for collaboration.
 - [Cryptpad](https://cryptpad.fr/) - Collaboration suite, encrypted and open-source.
 - [Etherpad](https://etherpad.org/) - Highly customizable open source online editor providing collaborative editing in really real-time.
-- [Skiff](https://skiff.com/) - End-to-end encrypted real-time document collaboration and file storage.
 
 
 ## Online Phone Providers


### PR DESCRIPTION
Skiff is defunct and shutting down in 6 months, this PR removes it.

https://skiff.com/data-migration