### PR TITLE
Add Unidentified Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The primary focus of this list is to provide alternatives that prioritize privac
 - [Shynet](https://github.com/milesmcc/shynet) - Modern, privacy-friendly, and detailed web analytics that works without cookies or JS.
 - [Swetrix](https://swetrix.com) - Privacy-focused, fully cookieless and opensource (and selfhostable) web-analytics service.
 - [Umami](https://umami.is/) - A simple, fast, website analytics alternative to Google Analytics.
+- [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based tracking that works everywhere (web, command-line, email, etc). No account required. Developer friendly.
 
 ## Android
 


### PR DESCRIPTION
### Unidentified Analytics
* [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based cross-plafform tracking, useful in websites, shell scripts, and anywhere you can post images or call urls. Source code available at [actuallymentor/unidentified-analytics](https://github.com/actuallymentor/unidentified-analytics)
* **License**: MIT
* **Why do you think this helps users privacy?**: It tracks no personally identifiable data from the person doing the tracking, and the person being tracked.
* **Under what section should this service be listed?**: Analytics
* **Additional comments / info**: I made this tool to track the usage of my moderately popular [mac battery limiting tool](https://github.com/actuallymentor/battery). It's a very convenient way to add "minimum viable tracking" to open source projects. It is very developer friendly, and is unlikely to be useful to commercial players. It's been up and running since feb 2023, though I squashed the dev history today so it looks only today years old on Github.

**Example usage:**

This is a tracking pixel: ![Privacy friendly user statistics pixel](https://unidentifiedanalytics.web.app/touch/?namespace=pupil-shut-ourselves-said) (👈 invisible svg right there)

[And this is where you can see the stats](https://unidentifiedanalytics.web.app/stats/pupil-shut-ourselves-said).

Screenshot of a namespace with data:

<img width="1222" alt="Screenshot 2024-04-03 at 12 57 57" src="https://github.com/pluja/awesome-privacy/assets/9071382/b8d503f2-0bbf-41c2-bbd1-39aa2efb28d9">

