### PR TITLE
Replace Quillnote by Quillpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Notally](https://github.com/OmGodse/Notally) - A beautiful notes app (local only, no sync).
 - [Notesnook](https://notesnook.com/) - Open source zero knowledge private note taking.
 - [Obsidian](https://obsidian.md) - Obsidian is the private and flexible note‑taking app. Closed source but has no trackers (website / apps) and E2EE sync. 
-- [Quillnote](https://qosp.org/#/) - Take beautiful markdown notes and stay organized with task lists.
+- [Quillpad](https://quillpad.github.io/) - Take beautiful markdown notes and stay organized with task lists. Fork of Quillnote.
 - [SiYuan](https://github.com/siyuan-note/siyuan) - A local-first personal knowledge management system.
 - [Standard Notes](https://standardnotes.org/) - A free, open-source, and completely encrypted notes app.
 - [TinyList](https://tinylist.app/) - Create and share notes and checklists, without sacrificing your privacy.


### PR DESCRIPTION
Quillnote seems to have been abandoned : it hasn't been updated for two years and links to official website and Play Store app don't work anymore.

Therefore I replaced it with an active fork, [Quillpad](https://github.com/quillpad/quillpad).