### PR TITLE
Replace LinkFree with BioDrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 ## Link in Bio Tools
 
 - [Keyoxide](https://keyoxide.org/) - A modern, secure and privacy-friendly platform to establish your decentralized online identity.
-- [LinkFree](https://github.com/EddieHubCommunity/LinkFree) - Connect to your audience with a single link. Showcase the content you create and your projects in one place. Make it easier for people to find, follow and subscribe.
+- [BioDrop](https://github.com/EddieHubCommunity/BioDrop) - Connect to your audience with a single link. Showcase the content you create and your projects in one place. Make it easier for people to find, follow and subscribe.
 - [LinkStack](https://linkstack.org/) - Self-hosted open-source Linktree alternative.
 
 ## Link Shorteners


### PR DESCRIPTION
Updated the name of LinkFree to BioDrop as it has been renamed. See https://github.com/pluja/awesome-privacy/issues/444