### PR TITLE
Remove hCaptcha from recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ Go to the [Text To Speech](#text-to-speech) section.
 Google captchas use cookies to track users and rank their IPs.
 
 - Google reCAPTCHA [![](https://shields.tosdr.org/en_217.svg)](https://tosdr.org/en/service/217)
+- hCaptcha [![](https://shields.tosdr.org/en_2207.svg)](https://tosdr.org/en/service/2207)
 
 <img width="16" src="misc/check.png"> </img>  **Instead use**
-- [hCaptcha](https://www.hcaptcha.com/) - Privacy-first CAPTCHA for web, mobile, and more.
 - [mCaptcha](http://mcaptcha.org/) ([repo](https://github.com/mCaptcha/mCaptcha)) - An open-source CAPTCHA system with seamless UX.  mCaptcha uses SHA256 based proof-of-work (PoW) to rate limit users.
 - [OOPSpam](https://www.oopspam.com/) - No-captcha, privacy-friendly anti-spam, anti-bot API. Requires no personal data for detection. Supports popular platforms like WordPress. Privacy commitment in their mission statement.
 


### PR DESCRIPTION
hCaptcha is NOT a privacy-friendly solution. It violates GDPR, uses third-party tracking and advertising cookies. See report: https://tosdr.org/en/service/2207