### PR TITLE
Remove OOPSpam - not privacy-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,6 @@ Google captchas use cookies to track users and rank their IPs.
 <img width="16" src="misc/check.png"> </img>  **Instead use**
 - [Altcha.org](https://altcha.org) - Free, open-source and self-hosted CAPTCHA alternative using proof-of-work mechanism.
 - [mCaptcha](http://mcaptcha.org/) ([repo](https://github.com/mCaptcha/mCaptcha)) - An open-source CAPTCHA system with seamless UX.  mCaptcha uses SHA256 based proof-of-work (PoW) to rate limit users.
-- [OOPSpam](https://www.oopspam.com/) - No-captcha, privacy-friendly anti-spam, anti-bot API. Requires no personal data for detection. Supports popular platforms like WordPress. Privacy commitment in their mission statement.
 
 ## Commenting Engines
 


### PR DESCRIPTION
Upon closer inspection, OOPSpam is not what it seems, it directly violates GDPR in several ways (but the website says it's compliant) and the website uses third-party tracking cookies, namely tolt.io for affiliate marketing.

Highlights from the [OOPSpam's Privacy Policy](https://www.oopspam.com/privacypolicy):

- (!) OOPSpam.com transfers your data outside your jurisdiction - "Your information, including Personal Data, may be transferred to — and maintained on — computers located outside of your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from your jurisdiction."
- (!) OOPSpam.com is using your data "to provide and improve the Service.". It is unclear whether its the submitted user data or customer's personal information.
- OOPSpam.com collects "several different types of information for various purposes to provide and improve [their] Service to you."
- OOPSpam.com is using cookies "and similar tracking technologies to track the activity on our Service and hold certain information."