### PR TITLE
Remove blackhole (removed from Github)

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,6 @@ With email aliases, you can finally create a different identity for each website
 - [Koel](https://koel.dev/) - a personal music streaming server that works.
 - [Nuclear](https://nuclear.js.org/) - Modern music player focused on streaming from free sources.
 - [Navidrome](https://navidrome.org/) - Lightweight, fast and self-contained personal music streamer.
-- <img width="16" src="misc/android.png"> [BlackHole](https://github.com/Sangwan5688/BlackHole) - A Music Player App made with Flutter 
 - <img width="16" src="misc/android.png"> [mucke](https://github.com/moritz-weber/mucke) - A music player for local files with unique custom playback options.
 
 **Spotify alternative clients**


### PR DESCRIPTION
The Blackhole repository has been removed from GitHub.

While [someone has reuploaded it](https://github.com/StarsWarrior/BlackHole), I have not reviewed this new repository. For now, it seems best not to include Blackhole in the list.