### PR TITLE
Updated simplytranslate source code URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,7 +1289,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 
 <img width="16" src="misc/check.png"> </img> **Alternative Google Translate frontends**
 - [Lingva](https://github.com/TheDavidDelta/lingva-translate) - Alternative front-end for Google Translate. [Demo](https://lingva.ml/).
-- [Simplytranslate](https://git.sr.ht/~metalune/simplytranslate_web) - Alternative front-end for Google Translate and LibreTranslate. [Demo](https://simplytranslate.org/)
+- [Simplytranslate](https://codeberg.org/ManeraKai/simplytranslate) - Alternative front-end for Google Translate and LibreTranslate. [Demo](https://simplytranslate.org/)
 
 ## Uncategorized
 - [Skymap](https://skymaponline.net/) - Open online planetarium program.


### PR DESCRIPTION
It seems SimplyTranslate moved their source code to codeberg. New repo URL is taken from their [Demo](https://simplytranslate.org/) website.