### PR TITLE
Added Floccus for bookmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Go to the [Text To Speech](#text-to-speech) section.
 - [LinkDing](https://github.com/sissbruecker/linkding)
 - [Shiori](https://github.com/go-shiori/shiori)
 - [Wallabag](https://wallabag.org/) - Open-source, optionally self-hosted, read it later server. Provides paid hosted service with privacy in mind.
+- [Floccus](https://floccus.org/) - Sync your bookmarks privately across browsers and devices.
 
 ### Book and web annotations/highlights management
 


### PR DESCRIPTION
Floccus is free and open-source software (MPL 2.0, see [Github repository](https://github.com/floccusaddon/floccus).

It is different from other solutions in the list because it is not a self-hosted bookmark manager, it just uses a little space in any cloud or Git repository your already have. That makes it more accessible for most people, I suppose.