### PR TITLE
Add AliasVault - open source password manager with built-in email server

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ GNU/Linux is a family of free (as in freedom and as in free beer) and open sourc
 - Dashlane
 
 ✅  **Instead use**
+- [AliasVault](https://www.aliasvault.net) - An open source E2EE password & alias manager with a built-in email alias server
 - [Bitwarden](https://bitwarden.com) - An open source cloud based password manager.
   - [vaultwarden](https://github.com/dani-garcia/vaultwarden/) - Unofficial Bitwarden compatible self-hosted server, formerly known as bitwarden_rs.
 - [KeepassXC](https://keepassxc.org/) - Securely store passwords using industry standard encryption, no sync just storage.


### PR DESCRIPTION
Hi there!

I would like to ask for my new open-source app called AliasVault to be included in the awesome-privacy list. AliasVault is an open-source and end-to-end encrypted password manager with a built-in email server. It helps you by creating alternative identities, passwords and email addresses for every website you use. It's fully open-source and you can use the cloud-hosted version or self-host it on your own server.

I've checked all the requirements:
- [x] Clear privacy-oriented / own your data policy. --> check.
- [x]  No user-tracking on project website. Only tracking listed under [Analytics](https://github.com/pluja/awesome-privacy#analytics) allowed. --> I'm using Plausible which is in the allowed list.
- [x]  Open source code is very valuable since it allows you to trust in the project (you can review the code) and not just trust the words. But some service without Open Source code may be added if there is special trust from community and has a good history privacy-wise. --> Project is fully open-source, see repository: https://github.com/lanedirt/AliasVault

For more information about AliasVault:
- Online demo (cloud hosted): https://www.aliasvault.net/
- GitHub repo and installation instructions: https://github.com/lanedirt/AliasVault
- Documentation: https://docs.aliasvault.net/

I hope AliasVault can be included in the list so more people can find it. Thanks for your time!