### PR TITLE
Add scrt.link/Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ on the DMCrypt kernel module.
 - [Snapdrop](https://github.com/RobinLinus/snapdrop) - A Progressive Web App for local file sharing inspired by Apple's Airdrop.
 - [Winden](https://winden.app/) - A convenient version of Magic Wormhole you can use from within your browser. No need to install an app.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
+- [scrt.link](https://scrt.link/file) - End-to-end encrypted file transfer. Up to 100GB and 30 days retention. Stored in Switzerland.
 
 [Back to top 🔝](#contents)
 
@@ -1010,6 +1011,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [NoPaste](https://github.com/bokub/nopaste) - Open Source pastebin alternative that works with no database, and no back-end code. Instead, the data is compressed and stored entirely in the link that you share, nowhere else.
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin) - A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
+- [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
**scrt.link** lets you share sensitive information online: End-to-end encrypted. Ephemeral. Open source.

**License:** MIT
**Why do you think this helps users privacy?:** It is important to keep confidential information out of email, Slack, Teams, Whatsapp or any other communication channel. A one-time disposable link guarantees your secrets can only ever be accessed once - before being destroyed forever.
**Under what section should this service be listed?:** "Pastebin and Secret Sharing" as well as "File Management and Sharing" since it offers both.

**Additional comments / info:** None