### PR TITLE
Add CarryPass to Password Managers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ GNU/Linux is a family of free (as in freedom and as in free beer) and open sourc
 ✅  **Instead use**
 - [Bitwarden](https://bitwarden.com) - An open source cloud based password manager.
   - [vaultwarden](https://github.com/dani-garcia/vaultwarden/) - Unofficial Bitwarden compatible self-hosted server, formerly known as bitwarden_rs.
+- [CarryPass](https://carrypass.net) - Zero-knowledge PWA password manager with deterministic generation, encrypted vaults, and team collaboration. ([Source](https://github.com/racz-zoltan/racz-zoltan.github.io)) `MIT`
 - [KeepassXC](https://keepassxc.org/) - Securely store passwords using industry standard encryption, no sync just storage.
   - [KeepassDX](https://www.keepassdx.com/) for Android.
   - [Strongbox](https://strongboxsafe.com/) for iOS.


### PR DESCRIPTION
CarryPass is a zero-knowledge, offline-first password manager built as a PWA. It uses deterministic password generation (Argon2 + PBKDF2 + AES-CTR) and AES-GCM-encrypted vaults per user or team.

It works entirely client-side with no backend or sync needed, and supports team collaboration, QR onboarding, and TOTP-secured access. Privacy-focused by design.