### PR TITLE
Add Linguist, a privacy-focused translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1586,6 +1586,9 @@ Please read about what the addon does before installing. If you don't understand
 #### Useful Tools
 - [Single File](https://github.com/gildas-lormeau/SingleFile) - Save a faithful copy of an entire web page in a single HTML file so you can use it offline.
 
+#### Translation
+- [Linguist](https://github.com/translate-tools/linguist) - a privacy‑focused translation solution in-browser that has an embedded offline translator, and lets users create [custom translators](https://linguister.io/docs/CustomTranslator) to use any translation API, even if it's locally deployed. Full-page translation, selected text translation, dictionary, history, and other features you may expect of a full-featured translation solution in-browser.
+
 ### Browser Sync
 - [xBrowserSync](https://www.xbrowsersync.org/) - Browser syncing as it should be: secure, anonymous and free!
 


### PR DESCRIPTION
Linguist have embedded offline translator, and let user add custom translator implementations as javascript code, so user may literally use any translation service in the world, for example deploy LLAMA locally and run it as translation service.

GitHub: https://github.com/translate-tools/linguist
Repo with a popular custom translators for Linguist: https://github.com/translate-tools/linguist-translators