### PR TITLE
add new section: Android Debloat Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@
 
 ### Android Debloat Tools
 ⛔ **Avoid**
-- ADB Control - A simple adb wrapper with a [terrible privacy policy](https://adbappcontrol.com/en/terms/) to collect things like device information and what applications you install/unsinstall.
+- ADB AppControl - A simple adb wrapper with a [terrible privacy policy](https://adbappcontrol.com/en/terms/) to collect things like device information and what applications you install/unsinstall.
 
 ✅ **Instead use**
 - [Universal Android Debloater](https://github.com/0x192/universal-android-debloater) - Cross-platform GUI written in Rust using ADB to debloat non-rooted android devices. Improve your privacy, the security and battery life of your device.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Analytics](#analytics)
 - [Android](#android)
   - [Android App Store](#android-app-store)
+  - [Android Debloat Tools](#android-debloat-tools)
   - [Android Dialer](#android-dialer)
   - [Android File Manager](#android-file-manager)
   - [Android Gallery](#android-gallery)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@
 - ADB AppControl - A simple adb wrapper with a [terrible privacy policy](https://adbappcontrol.com/en/terms/) to collect things like device information and what applications you install/unsinstall.
 
 ✅ **Instead use**
-- [Universal Android Debloater](https://github.com/0x192/universal-android-debloater) - Cross-platform GUI written in Rust using ADB to debloat non-rooted android devices. Improve your privacy, the security and battery life of your device.
+- [Universal Android Debloater Next Generation](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/) - Cross-platform GUI written in Rust using ADB to debloat non-rooted android devices. Improve your privacy, the security and battery life of your device.
 
 ### Android Dialer
 ⛔ **Avoid**

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@
 ### Alternative Google Play Store clients
 - [Aurora Store](https://auroraoss.com/download/#aurora-store) - Aurora Store is an open-source alternative Google Play Store frontend client with privacy and modern design in mind.
 
+### Android Debloat Tools
+⛔ **Avoid**
+- ADB Control - A simple adb wrapper with a [terrible privacy policy](https://adbappcontrol.com/en/terms/) to collect things like device information and what applications you install/unsinstall.
+
+✅ **Instead use**
+- [Universal Android Debloater](https://github.com/0x192/universal-android-debloater) - Cross-platform GUI written in Rust using ADB to debloat non-rooted android devices. Improve your privacy, the security and battery life of your device.
+
 ### Android Dialer
 ⛔ **Avoid**
 


### PR DESCRIPTION
add: 'Universal Android Debloater Next Generation' tool for uninstalling or hiding unwanted OEM bloatware apps.

effectively a GUI wrapper for adb commands:

- Uninstall: `pm uninstall --user <user> <package>`
- Disable: `pm disable-user --user <user> <package>` + `pm am force-stop --user <user> <package>` + `pm clear --user <user> <package>`