### PR TITLE
Add Confidential AI section with privacy-preserving solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ Go to the [Text To Speech](#text-to-speech) section.
 - [Stable Diffusion](https://github.com/Stability-AI/stablediffusion) - High-Resolution Image Synthesis with Latent Diffusion Models.
 	- [Stable Diffusion Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) - A browser interface for Stable Diffusion.
 
+#### Confidential AI
+
+- [dstack](https://github.com/Dstack-TEE/dstack) - Open-source framework for deploying AI models with hardware-enforced privacy using confidential computing. Protects AI workloads and data during processing with Intel TDX and NVIDIA Confidential Computing technologies.
+- [Phala Cloud](https://cloud.phala.network) - Serverless confidential AI deployment platform built on dstack. Deploy AI models with hardware-enforced privacy and familiar Docker Compose workflow.
+- [redpill](https://redpill.ai) - Confidential AI model API platform providing privacy-preserving access to large language models through confidential computing environments.
+
 [Back to top 🔝](#contents)
 
 ## Bookmarking


### PR DESCRIPTION
## Summary
Added new "Confidential AI" subsection to the Artificial Intelligence section featuring three privacy-preserving AI solutions:

- **dstack** - Open-source framework for confidential AI deployment
- **Phala Cloud** - Serverless confidential AI platform built on dstack
- **redpill** - Confidential AI model API platform

## Why include these
These solutions address the privacy concerns outlined in the AI section by providing hardware-enforced privacy and confidential computing technologies. They offer alternatives to cloud-based AI services that collect and store user data, enabling privacy-preserving AI deployment and inference.