### PR TITLE
Add Storyden to Reddit (self-hosted) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,10 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 - [Lemmy](https://join.lemmy.ml/) [🧩](#icons) - A federated and open alternative to Reddit in Rust.
 - [SaidIt](https://saidit.net/) - Open source Reddit clone.
 
+#### Self-hosted
+
+- [Storyden](https://www.storyden.org) - Self hosted Reddit-like forum, link aggregator and knowledgebase.
+
 ✅ **Privacy respecting Reddit clients:**
 - [Libreddit](https://github.com/libreddit/libreddit) - ~Private Reddit front-end written in Rust~ [No longer working - Read here](https://github.com/libreddit/libreddit/issues/840)
 - [Redlib](https://github.com/redlib-org/redlib) - An alternative private front-end to Reddit, with its origins in Libreddit.


### PR DESCRIPTION
Hey, love this list! Hopefully this is in the right section and the formatting is good (I copied the "Self hosted" header from the Twitter section) 

Storyden is a self-hosted, open source minimalist yet scalable forum-like platform modelled after Reddit and oldschool forums. Privacy, security and anonymity are first-class citizens in that you don't even need to collect email addresses for sign-up if you choose so.