### PR TITLE
Add Sync-in to Cloud Storage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Google captchas use cookies to track users and rank their IPs.
 - **OneDrive** - Microsoft owned, privacy policy is [very bad](https://tosdr.org/en/service/244). The data is stored in their remote servers where you lose control of it. They use trackers. No encryption available.
 
 ✅  **Instead use**
+- [Sync-in](https://sync-in.com/) - The secure, open-source platform for file storage, sharing, collaboration, and syncing.
 - [Nextcloud](https://nextcloud.com/) - The open source self-hosted productivity platform that keeps you in control.
 - [Seafile](https://www.seafile.com/en/home/) - High performance file syncing and sharing. It includes a Wiki, WYSIWYG editing and other knowledge management features.
 - [Peergos](https://peergos.org/) - Secure and private space online where you can store, share and view your photos, videos, music and documents. Also includes a calendar, news feed, task lists, chat and email client. Open source and self-hostable.


### PR DESCRIPTION
I’d like to suggest adding Sync‑in (https://sync‑in.com/) to the list :)

It's an open-source, self-hosted platform for secure file storage, real-time collaboration, sharing, and synchronization, with granular permissions, no tracking, and desktop app + WebDAV support.

**GitHub** : https://github.com/Sync-in




