### PR TITLE
Update bookmarking recommendations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,16 +283,16 @@ Go to the [Text To Speech](#text-to-speech) section.
 ## Bookmarking
 ⛔ **Avoid**
 - Evernote Web Clipper -  [Bad privacy policy](https://tosdr.org/en/service/207). [Apps have many trackers](https://reports.exodus-privacy.eu.org/en/reports/com.evernote/latest/) and require too many permissions.
-- Karakeep (previously Hoarder) - Defaults to [using ChatGPT](https://docs.karakeep.app/openai] for bookmarks.
 
 ✅  **Instead use**
+- [42links](https://42links.tuxproject.de) - Open-source, self-hosted, minimalist bookmark storage service.
+- [Floccus](https://floccus.org/) - Sync your bookmarks privately across browsers and devices.
 - [Grimoire](https://github.com/goniszewski/grimoire) - Modern, open source, self-hosted bookmark manager.
+- [Karakeep](https://karakeep.app/) - (previously Hoarder) Open source "Bookmark Everything" app that uses AI for automatically tagging the content you throw at it.
 - [LinkAce](https://github.com/Kovah/LinkAce)
 - [LinkDing](https://github.com/sissbruecker/linkding)
 - [Shiori](https://github.com/go-shiori/shiori)
 - [Wallabag](https://wallabag.org/) - Open-source, optionally self-hosted, read it later server. Provides paid hosted service with privacy in mind.
-- [Floccus](https://floccus.org/) - Sync your bookmarks privately across browsers and devices.
-- [42links](https://42links.tuxproject.de) - Open-source, self-hosted, minimalist bookmark storage service.
 
 ### Book and web annotations/highlights management
 


### PR DESCRIPTION
Added Karakeep to the 'Avoid' section and 42links to the 'Instead use' section. Karakeep replaces Pocket which is now defunct.

(Disclosure: 42links is mine, but it *is* privacy-aware, so am I.)