### PR TITLE
add coding assistants section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Opt for open-source and P2P alternatives that prioritize data privacy, eliminate
 
 ### Coding Assistants
 
-- [VSCode AI Chat](https://github.com/dimslaev/ai-chat) - Privacy-first AI coding assistant. Zero telemetry, local data only, manual context control. Works with any OpenAI-compatible API, (Infomaniak, Ollama).
+- [VSCode AI Chat](https://github.com/dimslaev/ai-chat) - Privacy-first AI coding assistant. Zero telemetry, local data only, manual context control. Works with any OpenAI-compatible API, locally or hosted.
 
 [Back to top 🔝](#contents)
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [Design Tools](#design-tools)
 - [Developer Tools](#developer-tools)
     - [IDEs](#ides)
+    - [Coding Assistants](#coding-assistants)
 - [Domain Registrar](#domain-registrar)
 - [Download Manager](#download-manager)
 - [Encryption](#encryption)
@@ -398,6 +399,10 @@ Opt for open-source and P2P alternatives that prioritize data privacy, eliminate
 ✅ Instead use
 - [Neovim](https://neovim.io/) - Hyperextensible Vim-based text editor.
 - [VSCodium](https://vscodium.com/) - Free/Libre Open Source Software Binaries of VSCode. Vscode source code is open source (MIT-licensed), but the product available for download (Visual Studio Code) is licensed under [this not-FLOSS license](https://code.visualstudio.com/license) and contains telemetry/tracking.
+
+### Coding Assistants
+
+- [VSCode AI Chat](https://github.com/dimslaev/ai-chat) - Privacy-first AI coding assistant. Zero telemetry, local data only, manual context control. Works with any OpenAI-compatible API, (Infomaniak, Ollama).
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
VSCode AI Chat is a privacy-first AI coding assistant that gives developers manual control over context. Unlike mainstream AI assistants, it:

- **Zero telemetry**: No usage tracking or analytics
- **Local storage only**: Conversations stay in workspace, never cloud
- **Manual file selection**: You choose what gets sent to optimise context for local LLM usage.
- **Privacy-focused providers**: Default to Infomaniak (Swiss, GDPR-compliant, no training on data)
- **Self-hosted support**: Ollama integration for fully local LLMs