### PR TITLE
Add Privsen entry to file sharing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [Peergos](https://peergos.org/) - Secure and private space online where you can store, share and view your photos, videos, music and documents. Also includes a calendar, news feed, task lists, chat and email client. Open source and self-hostable.
 - [Proton Drive](https://proton.me/drive) - End-to-end encrypted Swiss vault for your files that protects your data. [Read this article over Climate activist arrest](https://protonmail.com/blog/climate-activist-arrest/).
 - [PrivateStorage](https://private.storage/) - Accountless, privacy-focused cloud storage and folder synchronization with client-side encryption.
+- [Privsen](https://privsen.com) - Zero-knowledge encrypted file sharing up to 15GB. Files encrypted client-side with AES-256-GCM before upload. Auto-expiry. No account needed.
 
 **Other useful tools**
 - [Cryptomator](https://cryptomator.org) - Cryptomator encrypts your data quickly and easily. Afterwards you upload them protected to your favorite cloud service
@@ -1035,6 +1036,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
 - [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
 - [dele-to](https://dele.to) - Open Source. Modern app to share sensitive credentials and secrets securely with client-side AES-256 encryption, zero-knowledge architecture, and automatic self-destruction.
+- [Privsen](https://privsen.com) - Zero-knowledge encrypted pastebin, file sharing, polls, and self-destructing messages. Client-side AES-256-GCM encryption. No signup required.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What I'm adding

Added [Privsen](https://privsen.com) to two sections:

1. **Cloud Storage** - Zero-knowledge encrypted file sharing (up to 15GB)
2. **Pastebin and Secret Sharing** - Encrypted pastebin with self-destructing messages

## Why it fits

- ✅ Zero-knowledge architecture (server never sees decryption keys)
- ✅ Client-side AES-256-GCM encryption
- ✅ No account/signup required
- ✅ Auto-expiring files
- ✅ Free to use
- ✅ Privacy-focused alternative to WeTransfer, Pastebin, etc.