### PR TITLE
Add Tokyo VPN Speed Monitor to VPN Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,6 +1546,7 @@ Such programs come filled with trackers and telemetry. You can get a full list o
 
 - Closed source VPN apps such as Surfshark or NordVPN may be less trustworthy as nobody can be sure how they handle your data. Also, paying with Credit Card will get you identified on the payment. Furthermore, if you need to give your email it will also identify you if this same email has been used in other services.
 
+- [Tokyo VPN Speed Monitor](https://www.blstweb.jp/network/vpn/) - Real-time VPN speed testing from Tokyo with automated measurements every 6 hours. 15 VPN providers tested with open data and free security diagnostic tool. Open source on [GitHub](https://github.com/hmy0210/vpn-stability-ranking).
 
 ✅  **Instead use**
 

--- a/README.md
+++ b/README.md
@@ -1546,7 +1546,7 @@ Such programs come filled with trackers and telemetry. You can get a full list o
 
 - Closed source VPN apps such as Surfshark or NordVPN may be less trustworthy as nobody can be sure how they handle your data. Also, paying with Credit Card will get you identified on the payment. Furthermore, if you need to give your email it will also identify you if this same email has been used in other services.
 
-- [Tokyo VPN Speed Monitor](https://www.blstweb.jp/network/vpn/) - Real-time VPN speed testing from Tokyo with automated measurements every 6 hours. 15 VPN providers tested with open data and free security diagnostic tool. Open source on [GitHub](https://github.com/hmy0210/vpn-stability-ranking).
+- [Tokyo VPN Speed Monitor](https://www.blstweb.jp/network/vpn/tokyo-vpn-speed-monitor/) - Real-time VPN speed testing from Tokyo with automated measurements every 6 hours. 15 VPN providers tested with open data and free security diagnostic tool. Open source on [GitHub](https://github.com/hmy0210/vpn-stability-ranking).
 
 ✅  **Instead use**
 


### PR DESCRIPTION
## What

Adding **Tokyo VPN Speed Monitor** - a real-time VPN speed testing project from Tokyo with automated measurements and security diagnostics.

## Why

- **Real-time data**: Automated measurements every 6 hours (645+ tests over 2 weeks)
- **Asian perspective**: Tests from Tokyo, Japan (underrepresented region in VPN testing)
- **Open data**: All results publicly available with API access
- **Comprehensive**: 15 VPN providers tested with statistical analysis
- **Privacy-focused**: Free VPN leak detection tool (DNS/WebRTC/IPv6) - 100% client-side, no tracking
- **Open source**: MIT License, all code public on GitHub

## Details

- **Website**: https://www.blstweb.jp/network/vpn/
- **GitHub**: https://github.com/hmy0210/vpn-stability-ranking
- **Data**: 645+ measurements over 2 weeks
- **Update frequency**: Every 6 hours
- **Features**: Speed ranking, price monitoring, outage detection, VPN diagnosis tool
- **Tech**: Google Apps Script (free tier) + Spreadsheet + HTML/JS

## Value to awesome-privacy users

1. **Unbiased data**: No affiliate links, no VPN sponsorships
2. **Asian perspective**: First major VPN testing project from Tokyo
3. **Continuous monitoring**: Not just one-time tests
4. **Free tools**: VPN leak detection tool available to all
5. **Educational**: All code open source for learning

This fills a gap in VPN testing from Asian locations and provides transparent, automated testing data.

## Checklist

- [x] Project is open source (MIT License)
- [x] No tracking or user data collection
- [x] Privacy-focused (VPN diagnosis tool is 100% client-side)
- [x] Active maintenance (2 weeks running, ongoing)
- [x] Well-documented (README, SETUP guide, API docs)
- [x] Provides value to privacy-conscious users