### PR TITLE
Add TorForge - Transparent Tor Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 
 #### Desktop
 - [Thunderbird](https://www.thunderbird.net) - A free customizable open source email client.
+- [TorForge](https://github.com/jery0843/torforge) - Transparent Tor proxy with kernel-level iptables routing, post-quantum encryption (Kyber768), kill switch, steganography mode, and AI circuit selection.
 
 ### Email Alias Services (Anonymous Forwarding)
 

--- a/README.md
+++ b/README.md
@@ -748,7 +748,6 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 
 #### Desktop
 - [Thunderbird](https://www.thunderbird.net) - A free customizable open source email client.
-- [TorForge](https://github.com/jery0843/torforge) - Transparent Tor proxy with kernel-level iptables routing, post-quantum encryption (Kyber768), kill switch, steganography mode, and AI circuit selection.
 
 ### Email Alias Services (Anonymous Forwarding)
 
@@ -1165,6 +1164,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [TorForge](https://github.com/jery0843/torforge) - Transparent Tor proxy with kernel-level iptables routing, post-quantum encryption (Kyber768), kill switch, steganography mode, and AI circuit selection.
 
 ### Android
 


### PR DESCRIPTION
## Add TorForge

**Category:** Privacy Tools > Desktop

**Description:** TorForge is a transparent Tor proxy that routes all system traffic through Tor at the kernel level using iptables.

**Key Features:**
- Zero-config transparent proxying
- Kill switch (default DROP policy)
- Post-quantum encryption (CRYSTALS-Kyber768)
- Steganography mode
- Dead man's switch

**License:** MIT
**Source:** https://github.com/jery0843/torforge