### PR TITLE
Add EPUB Player to Text to Speech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,7 +1434,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 - [MeloTTS](https://github.com/myshell-ai/MeloTTS) - a high-quality multi-lingual text-to-speech library by MIT and MyShell.ai.
 - [Piper](https://github.com/rhasspy/piper) - A fast, local neural text to speech system that sounds great and is optimized for the Raspberry Pi 4.
 - [Espeak](https://github.com/espeak-ng/espeak-ng) - eSpeak NG is an open source speech synthesizer that supports more than hundred languages and accents. Voices will sound rather robotic.
-- [EPUB Player](https://epubplayer.com) - A fully-featured audiobook player with Audible-like UX, powered entirely by local TTS models. Converts EPUBs to audiobooks in-browser. No uploads, no accounts, works offline.
+- [EPUB Player](https://github.com/grworg/epubplayer) - A fully-featured audiobook player with Audible-like UX, powered entirely by local TTS models. Converts EPUBs to audiobooks in-browser. No uploads, no accounts, works offline.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
**EPUB Player** - [epubplayer.com](https://epubplayer.com) | [GitHub](https://github.com/grworg/epubplayer)

A free, open-source PWA that converts EPUB ebooks into audiobooks using neural text-to-speech.

**Why it fits this list:**

- **100% local processing** — All TTS runs in-browser via Web Workers (Kokoro, Piper, or browser TTS)
- **No uploads** — Books are stored in IndexedDB, never sent anywhere
- **No accounts** — No signup, no login, no tracking
- **No analytics** — Zero tracking or data collection
- **Works offline** — Full PWA with service worker
- **Open source** — MIT licensed

This directly addresses the privacy concerns in the TTS section: users can convert their ebooks to audio without sending text to any third-party cloud service.

**Checklist:**
- [x] Open source
- [x] Privacy-respecting (no tracking, local-only)
- [x] Actively maintained
- [x] Fits the category (Text to Speech)