### PR TITLE
Add Calendar section with privacy-respecting alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [Bookmarking](#bookmarking)
     - [Book and web annotations](#book-and-web-annotationshighlights-management)
 - [Captchas](#captchas)
+- [Calendar](#calendar)
 - [Commenting Engines (disqus)](#commenting-engines)
 - [Cloaking](#cloaking)
 - [Cloud Storage](#cloud-storage)
@@ -314,6 +315,22 @@ Google captchas use cookies to track users and rank their IPs.
 - [Altcha.org](https://altcha.org) - Free, open-source and self-hosted CAPTCHA alternative using proof-of-work mechanism.
 - [mCaptcha](http://mcaptcha.org/) ([repo](https://github.com/mCaptcha/mCaptcha)) - An open-source CAPTCHA system with seamless UX.  mCaptcha uses SHA256 based proof-of-work (PoW) to rate limit users.
 - [Private Captcha](https://github.com/PrivateCaptcha/PrivateCaptcha) - Privacy-first and self-hosted Proof-of-Work CAPTCHA alternative, made in EU.
+
+[Back to top 🔝](#contents)
+
+## Calendar
+
+⛔ **Avoid**
+
+- **Google Calendar** - Tracks your events, integrates with Google's advertising ecosystem, and your data is stored on Google's servers without end-to-end encryption.
+
+✅  **Instead use**
+
+- [🤖](#icons) [Etar](https://github.com/Etar-Group/Etar-Calendar) - Open-source calendar app for Android that works with any CalDAV server.
+- [🤖](#icons) [Fossify Calendar](https://github.com/FossifyOrg/Calendar) - Simple offline calendar app for Android with widget support.
+- [🤖](#icons) [KashCal](https://github.com/KashCal/KashCal) - Offline-first Android calendar with iCloud/CalDAV sync, full-text search, recurring events, and home screen widget. Apache 2.0 licensed.
+- [Nextcloud Calendar](https://apps.nextcloud.com/apps/calendar) - Calendar app for Nextcloud with CalDAV support. Self-hostable.
+- [Proton Calendar](https://proton.me/calendar) - End-to-end encrypted calendar from Proton. Part of the Proton privacy ecosystem.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Summary

Adds a new **Calendar** section to the list. Calendars contain sensitive personal information (appointments, meetings, locations, routines) and deserve a dedicated section.

## What's included

**Avoid:**
- Google Calendar (tracking, no E2EE)

**Alternatives:**
- **Etar** - Open-source Android calendar with CalDAV support
- **Fossify Calendar** - Simple offline Android calendar
- **KashCal** - Offline-first Android calendar with iCloud/CalDAV sync (Apache 2.0)
- **Nextcloud Calendar** - Self-hostable CalDAV calendar
- **Proton Calendar** - E2EE calendar from Proton

## Why this section?

Calendar data reveals:
- Daily routines and schedules
- Meeting participants and relationships
- Locations you visit
- Medical appointments
- Personal events

Currently the list has no dedicated calendar section, though calendars are a core productivity tool with significant privacy implications.

## Notes

- Added to Contents in alphabetical order (after Captchas, before Commenting Engines)
- Follows existing format with ⛔ Avoid / ✅ Instead use structure
- Includes 🤖 icon for Android apps per list convention