### PR TITLE
Add NoTrust.now to File Management and Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ on the DMCrypt kernel module.
 - [Lufi](https://framagit.org/fiat-tux/hat-softwares/lufi) - Let's Upload that FIle — File sharing software.
 - [Localsend](https://localsend.org/) - Share files to nearby devices. Free, open source, cross-platform.
 - [Magic Wormhole](https://github.com/magic-wormhole/magic-wormhole) - Get things from one computer to another, safely.
+- [NoTrust.now](https://notrust.now) - Zero-knowledge secret sharing with self-destructing links. Supports post-quantum encryption (ML-KEM-768, ML-DSA-65). No registration required.
 - [OnionShare](https://github.com/micahflee/onionshare) - An open source tool that lets you securely and anonymously share files, host websites, and chat with friends using the Tor network.
 - [Paperless](https://github.com/the-paperless-project/paperless) - [Now archived] Scan, index, and archive all of your paper documents.
 	- [Paperless-ng](https://github.com/jonaswinkler/paperless-ng) - [inactive] A supercharged version of paperless: scan, index and archive all your physical documents.


### PR DESCRIPTION
## Description

Adding [NoTrust.now](https://notrust.now) - a zero-knowledge secret sharing tool with post-quantum cryptography.

## Features

- Zero-knowledge architecture (client-side encryption with ChaCha20-Poly1305)
- Optional post-quantum encryption using NIST-approved ML-KEM-768 and ML-DSA-65
- Self-destructing links with configurable expiration
- P2P mode for direct browser-to-browser sharing
- No registration required, 100% free

## Why include this?

- One of few tools offering post-quantum cryptography for secret sharing
- Fully client-side encryption (true zero-knowledge)
- Free and requires no account

## Entry added

```markdown
- [NoTrust.now](https://notrust.now) - Zero-knowledge secret sharing with self-destructing links. Supports post-quantum encryption (ML-KEM-768, ML-DSA-65). No registration required.
```