### PR TITLE
Add PasteGuard to ChatGPT alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [llama.cpp](https://github.com/ggerganov/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
+- [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 


### PR DESCRIPTION
Adds PasteGuard to the ChatGPT section.

**PasteGuard** - Privacy proxy that sits between your apps and LLM providers (OpenAI, Azure, etc.), detecting and masking personal data and secrets before they leave your network.

**Why it fits awesome-privacy:**
- Self-hosted, open source (Apache 2.0)
- No data collection, all processing happens locally
- Protects PII (names, emails, phones, credit cards) and secrets (API keys, tokens)
- OpenAI API compatible

GitHub: https://github.com/sgasser/pasteguard