### PR TITLE
Add BulkPicTools to Photo Editing (Web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 
 ✅  **Instead use**
 #### Web
+- [BulkPicTools](https://bulkpictools.com) - A high-performance, privacy-first bulk image processor for resizing, converting, and watermarking. Operates entirely in your browser; no image data is ever sent to any server. No cookies or tracking are used.
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
 
 #### Desktop


### PR DESCRIPTION
I'd like to suggest BulkPicTools for the Web Photo Editing section. It's a client-side tool built with Nuxt.js that processes images locally using Canvas API and Web Workers. We've focused heavily on privacy by ensuring no server-side uploads and using cookie-free analytics (Umami).