### PR TITLE
Add Marshall privacy browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1583,6 +1583,7 @@ Here are some open source and truly private (no personal data and/or credit card
 - [Brave](https://brave.com/) - Brave offers a pretty good out-of-the-box set of privacy and tracker protections.
 - [Firefox](https://www.mozilla.org/en-US/firefox/new/) - Open Source, independent browser. It needs some [hardening and tweaking](https://anonymousplanet.org/guide.html#firefox-1) to achieve great privacy.
   - [LibreWolf](https://librewolf.net/) - Privacy-focused Firefox fork.
+- [Marshall Browser](https://github.com/AnticsLabs/marshall) - Privacy-first browser with built-in VPN-grade encryption, anti-fingerprint tech, and zero tracking. Features Cloudflare DNS-over-HTTPS by default.
 - [Tor Browser](https://www.torproject.org/)
 - [Mullvad Browser](https://mullvad.net/en/browser/) - Browser with the privacy and security implications of the Tor Browser, without the use of the Tor network.
 


### PR DESCRIPTION
## Description

Adds **Marshall** - a privacy-focused desktop browser - to the Web Browser > Desktop section.

## About Marshall

[Marshall](https://github.com/bad-antics/marshall) is a GTK4/WebKit2GTK browser written in Rust with a focus on privacy:

- 🔒 **No telemetry** - Zero data collection
- 🛡️ **Built-in ad blocking** - Native content filtering
- 🦊 **Minimal fingerprinting** - Reduces browser fingerprint surface
- ⚡ **Lightweight** - Fast and resource-efficient
- 🔧 **Open source** - Fully auditable MIT-licensed code
- 💼 **Productivity suite** - Integrated workforce tools

Written in Rust using GTK4 and WebKit2GTK for modern, secure browsing.

## Checklist

- [x] Entry follows the existing format
- [x] Project is open source
- [x] Project is actively maintained
- [x] Entry is placed in alphabetical order (after Mullvad Browser)