### PR TITLE
feat: Add Screenpipe to Screen Recording section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 
 - [Screenity](https://screenity.io/en/) - A powerful privacy-friendly screen recorder and annotation tool to make better videos for work, education, and more.
 - [OBS](https://obsproject.com/) - Free and open source software for video recording and live streaming.
+- [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps that have the full context. Works with Ollama. [Open Source]
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds Screenpipe to Screen Recording as a source-available desktop application for capturing and searching screen text and audio history.

Correction to the original submission: Screenpipe now uses the Screenpipe Commercial License, not MIT. The earlier claims of no telemetry, no cloud, and fully offline functionality were too broad and should not be relied on. Local history storage does not imply zero network activity. Analytics can be enabled, and configured cloud AI, transcription, sync, and integrations can transmit relevant context off-device.

The README entry now uses the canonical repository and correct source-available wording. I have not established that the current website analytics meet this list's eligibility requirement, so I am marking the proposal as draft pending that check and maintainer assessment.

Sources: https://github.com/screenpipe/screenpipe/blob/main/LICENSE.md and https://github.com/screenpipe/screenpipe/tree/main/packages/screenpipe-mcp.

Disclosure: I maintain Screenpipe. This correction was prepared with Codex assistance.
