### PR TITLE
Add Deadhand Protocol to sensitive data sharing tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,6 +1030,7 @@ GNU/Linux is a family of free (as in freedom and as in free beer) and open sourc
 These tools are useful when sharing secrets, code snippets or any other kind of text with others in a private way.
 
 - [crypt.fyi](https://crypt.fyi) - Ephemeral zero-knowledge sensitive data sharing platform with web, cli, and chrome-extension clients
+- [Deadhand Protocol](https://deadhandprotocol.com) - Dead man's switch for seed phrases using Shamir's Secret Sharing. Includes visual cryptography, audio steganography, and CLI tools. Client-side splitting.
 - [NoPaste](https://github.com/bokub/nopaste) - Open Source pastebin alternative that works with no database, and no back-end code. Instead, the data is compressed and stored entirely in the link that you share, nowhere else.
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin) - A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.


### PR DESCRIPTION
### Description
Added [Deadhand Protocol](https://deadhandprotocol.com) - A dead man's switch for crypto inheritance using Shamir's Secret Sharing.

### Why it belongs
- Non-custodial crypto inheritance tool
- Uses industry-standard SSS cryptography
- Source-available under BSL 1.1
- Solves a real problem (billions in lost crypto due to dead owners)