### PR TITLE
Add n01d Machine to Privacy Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 ### Desktop
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
+- [n01d Machine](https://github.com/bad-antics/n01d-machine) - Secure cross-platform VM manager with sandboxing, Tor routing, VPN support (WireGuard/OpenVPN), and security profiles for isolated privacy-focused computing.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
 
 ### Android


### PR DESCRIPTION
## Description
Adding **n01d Machine** to the Privacy Tools section - a secure cross-platform virtual machine manager designed for privacy-focused computing.

## Features
- 🔒 **Security Profiles**: Paranoid, Stealth, Isolated, Pentesting modes
- 🧅 **Tor Integration**: Route all VM traffic through Tor with bridge support
- 🔐 **VPN Support**: WireGuard and OpenVPN with kill switch
- 🌐 **Network Isolation**: Full, Host Only, Internal, Tor Only, VPN Only modes
- 📦 **QEMU Sandboxing**: Each VM runs in sandbox mode
- 🖥️ **Cross-Platform**: Linux, Windows, macOS

## Why it fits Privacy Tools section
n01d Machine is specifically designed to help users:
- Run isolated VMs with Tor routing for anonymous browsing
- Set up air-gapped environments for sensitive work
- Prevent network leaks with kill switch and DNS protection
- Configure secure VM environments with one-click security profiles

## Repository
https://github.com/bad-antics/n01d-machine

Thank you for maintaining this awesome list! 🙏