### PR TITLE
Add NullSec Discord Shield to Discord section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1518,6 +1518,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 - [Replugged](https://replugged.dev/) - A continuation of the deprecated client mod [Powercord](https://powercord.dev).
 - [WebCord](https://github.com/SpacingBat3/WebCord) - A Discord and Fosscord API-less client made with the Electron.
 - [🤖](#icons) [Aliucord](https://github.com/Aliucord/Aliucord) - A modification for the Android Discord app that fully [disables the Discord Tracking](https://github.com/Aliucord/Aliucord/blob/main/Aliucord/src/main/java/com/aliucord/coreplugins/NoTrack.java).
+- [NullSec Discord Shield](https://github.com/bad-antics/nullsec-discord-shield) - Token hardening and anti-theft protection with AES-256-GCM encrypted vault, memory obfuscation, and grabber detection. Protects Discord tokens from malware.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Summary

Adding [NullSec Discord Shield](https://github.com/bad-antics/nullsec-discord-shield) to the Discord modifications/clients section.

## What it does

Discord Shield is a Rust-based security tool that protects Discord tokens from being stolen by malware:

- **Token Vault** - AES-256-GCM encrypted token storage with machine-bound keys
- **Memory Protection** - Anti-debug, memory guards, and injection detection  
- **File Monitoring** - Real-time LevelDB monitoring and suspicious file quarantine
- **Grabber Detection** - Identifies and blocks known token stealers

## Why it fits

Unlike client mods that just disable telemetry, Discord Shield actively protects your authentication tokens from being stolen by malware - a real privacy/security threat that affects many Discord users. It complements the existing Discord privacy tools in this list.

Open source under MIT license.