### PR TITLE
Add Cookie Guardian to Browser Addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,7 @@ Here are some open source and truly private (no personal data and/or credit card
 
 ### Browser Addons
 
+- [Cookie Guardian](https://chromewebstore.google.com/detail/cookie-guardian-auto-dele/gnoaanpbfnjakaddkecnnamnfkebhgle) - Auto-delete cookies when you close tabs. Privacy-first, open-source alternative to Cookie AutoDelete. MV3-compliant.
 #### Anti-tracking
 Please read about what the addon does before installing. If you don't understand what you are doing you could end up damaging your privacy. Also, too many addons can slow down your browsing experience.
 


### PR DESCRIPTION
## What is Cookie Guardian?

Cookie Guardian is a privacy-focused Chrome extension that automatically deletes cookies when you close tabs — the modern replacement for Cookie AutoDelete, which stopped working after Chrome's Manifest V3 transition.

- **Chrome Web Store**: https://chromewebstore.google.com/detail/cookie-guardian-auto-dele/gnoaanpbfnjakaddkecnnamnfkebhgle
- **Source Code**: https://github.com/curlyethan/cookie-guardian
- **Users**: 800+
- **Privacy**: Zero data collection, no tracking, fully auditable
- **MV3**: Fully Manifest V3 compliant

### Why add this?

Cookie AutoDelete was the go-to cookie management extension for years, but it stopped working when Chrome enforced Manifest V3. Cookie Guardian fills that gap with a modern, privacy-first approach — auto-deleting cookies on tab close, with whitelist/greylist support for trusted sites.

Open source, no data collection, no analytics. Built for privacy-conscious users.