### PR TITLE
Update Nuclear player website

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ With email aliases, you can finally create a different identity for each website
 - [Subsonic](https://www.subsonic.org/pages/index.jsp) - Your complete, personal music streamer.
 - [Ampache](https://ampache.org/) - A web based audio/video streaming application and file manager.
 - [Koel](https://koel.dev/) - a personal music streaming server that works.
-- [Nuclear](https://nuclear.js.org/) - Modern music player focused on streaming from free sources.
+- [Nuclear](https://nuclearplayer.com/) - Modern music player focused on streaming from free sources.
 - [Navidrome](https://navidrome.org/) - Lightweight, fast and self-contained personal music streamer.
 - [🤖](#icons) [mucke](https://github.com/moritz-weber/mucke) - A music player for local files with unique custom playback options.
 


### PR DESCRIPTION
### Description

Nuclear music player has a new website at: https://nuclearplayer.com/
Old domain was https://nuclear.js.org and is **no longer redirected**.

Source **reason**: https://github.com/js-org/js.org/issues/9295

Repository still at: https://github.com/nukeop/nuclear
