### PR TITLE
Add OpenClaw/ClawBox - Privacy-First AI Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
+- [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted AI assistant platform that runs on dedicated hardware ([ClawBox](https://self-hosted-ai-assistant.com)). All data stays local, supports Telegram/WhatsApp/Discord. Runs on NVIDIA Jetson at 15W.
 
 #### Copilot
 
@@ -627,6 +628,7 @@ Interesting articles: [1](https://www.theguardian.com/technology/2019/oct/09/ale
 ✅  **Instead use**
 - [Mycroft](https://mycroft.ai/) - The Private and Open Voice Assistant.
 - [Home Assistant](https://www.home-assistant.io/) - Open source home automation that puts local control and privacy first.
+- [ClawBox](https://personal-ai-server.com) - Pre-configured, always-on AI assistant hardware powered by NVIDIA Jetson. Privacy-first — all processing happens locally on your device.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
OpenClaw is a self-hosted AI assistant platform (184K+ stars) where all data stays on your local device. ClawBox is the pre-configured hardware (NVIDIA Jetson Orin Nano, 15W).

Added under:
- ChatGPT alternatives (self-hosted AI)
- Home Assistants (privacy-first alternative)

- https://github.com/openclaw/openclaw
- https://self-hosted-ai-assistant.com
- https://personal-ai-server.com