### PR TITLE
Add OpenClaw to ChatGPT alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
+- [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted AI assistant that keeps all conversations on your hardware while connecting to WhatsApp, Telegram, Discord, and 5 more channels. ([setup guide](https://clawdbot.blog/getting-started/installation/))
 
 #### Copilot
 


### PR DESCRIPTION
Adding [OpenClaw](https://github.com/openclaw/openclaw) to the ChatGPT alternatives section.

OpenClaw is a self-hosted AI assistant that keeps all conversations on your own hardware — no data leaves your network. It connects to eight messaging channels (WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, Signal) from a single deployment.

Privacy benefits:
- All data stays local — no cloud processing
- No third-party data collection or model training on your inputs
- Full control over data retention and access

- **GitHub**: https://github.com/openclaw/openclaw (190k+ stars, MIT)
- **Setup Guide**: https://clawdbot.blog/getting-started/installation/