### PR TITLE
Add vnsh to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
 - [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
 - [dele-to](https://dele.to) - Open Source. Modern app to share sensitive credentials and secrets securely with client-side AES-256 encryption, zero-knowledge architecture, and automatic self-destruction.
+- [vnsh](https://vnsh.dev) - Host-blind ephemeral pastebin with CLI. Server never sees decryption keys (stored in URL fragment). Client-side AES-256-CBC, auto-expiring links.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Adding vnsh

**Website:** https://vnsh.dev
**Source Code:** https://github.com/raullenchai/vnsh
**License:** MIT

### What is vnsh?

vnsh is a host-blind ephemeral pastebin/file sharing service with a focus on privacy.

**Privacy features:**
- **Zero-knowledge architecture** - Server stores encrypted blobs but never sees decryption keys
- **Keys in URL fragment** - The `#k=...&iv=...` fragment is never sent to the server
- **Client-side encryption** - AES-256-CBC encryption happens in browser/CLI
- **Ephemeral** - Auto-expiring links (24h default, configurable)
- **No accounts** - No registration or tracking

**Usage:**
```bash
# Install CLI
curl -sL vnsh.dev/i | sh

# Share encrypted content
echo "secret message" | vn
# Output: https://vnsh.dev/v/{id}#k={key}&iv={iv}
```

**Tech:** Cloudflare Workers + R2, zero-dependency CLI (curl + openssl)