### PR TITLE
Add Frontman to AI > Copilot section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Continue](https://github.com/continuedev/continue) - Open-source autopilot for VS Code and JetBrains—the easiest way to code with any LLM
 - [Cline](https://cline.bot/) - Open source AI coding for VSCode. See every decision and use your own models. 
 	- [RooCode](https://github.com/RooCodeInc/Roo-Code) - Cline fork with some improvements.
+- [Frontman](https://github.com/frontman-ai/frontman) - Open-source AI coding agent. Bring your own AI key — data stays local/private. No telemetry, no cloud dependency. Apache 2.0 licensed.
 
 #### ElevenLabs Text To Speech
 


### PR DESCRIPTION
## Summary

- Adds [Frontman](https://github.com/frontman-ai/frontman) to the **AI > Copilot** section as a privacy-focused alternative to GitHub Copilot and Cursor.

## Why Frontman belongs here

Unlike Copilot/Cursor which route all code through their cloud, Frontman is:

- **Self-hosted** — runs locally, no cloud dependency
- **Bring your own key** — you control which AI provider handles your code
- **No telemetry** — zero data collection
- **Open source** — Apache 2.0 licensed

Repository: https://github.com/frontman-ai/frontman