### PR TITLE
Add vnsh to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
 - [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
 - [dele-to](https://dele.to) - Open Source. Modern app to share sensitive credentials and secrets securely with client-side AES-256 encryption, zero-knowledge architecture, and automatic self-destruction.
+- [vnsh](https://github.com/raullenchai/vnsh) - Host-blind encrypted sharing for developers. AES-256-CBC encryption happens client-side; the server never sees keys or plaintext. Links auto-expire in 24h. Includes CLI, MCP (Claude Code), and Chrome Extension.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Summary
- Adds [vnsh](https://github.com/raullenchai/vnsh) to the **Pastebin and Secret Sharing** section
- vnsh is a host-blind encrypted sharing tool for developers with AES-256-CBC client-side encryption, 24h auto-expiring links, and integrations for CLI, MCP (Claude Code), and Chrome Extension
- The server implements a zero-knowledge architecture — it never sees decryption keys or plaintext

## Details
- **Website**: https://vnsh.dev
- **Source**: https://github.com/raullenchai/vnsh
- **License**: MIT
- **Key features**: Client-side AES-256-CBC encryption, burn-on-read, 24h expiry, CLI pipe support, MCP server for AI agents, Chrome Extension