### PR TITLE
Add VoxTap to Speech to Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1440,6 +1440,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 - [OpenAI Whisper](https://github.com/openai/whisper) - Whisper is a general-purpose speech recognition model that can be run locally offline. It can transcribe audio from and to multiple languages.
 	- [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.
  	- [Whishper](https://whishper-docs.pages.dev/) - A whisper frontend with subtitle editing and translation capabilities. 
+- [VoxTap](https://voxtap.app) - On-device voice-to-text for macOS. One hotkey to dictate anywhere. 100% offline, no cloud processing, no data leaves your Mac.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adding [VoxTap](https://voxtap.app) to the **Speech to Text** section.

VoxTap is a macOS voice-to-text app that runs 100% on-device:
- On-device AI model — no cloud processing, no data leaves your Mac
- No account required, no signup
- One hotkey to dictate anywhere (code editors, terminals, browsers)
- macOS 14+, $29 lifetime