### PR TITLE
Add bewCloud to Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Google captchas use cookies to track users and rank their IPs.
 - **OneDrive** - Microsoft owned, privacy policy is [very bad](https://tosdr.org/en/service/244). The data is stored in their remote servers where you lose control of it. They use trackers. No encryption available.
 
 ✅  **Instead use**
+- [bewCloud](https://bewcloud.com/) - A modern and simpler alternative to Nextcloud and ownCloud written in TypeScript.
 - [Nextcloud](https://nextcloud.com/) - The open source self-hosted productivity platform that keeps you in control.
 - [Seafile](https://www.seafile.com/en/home/) - High performance file syncing and sharing. It includes a Wiki, WYSIWYG editing and other knowledge management features.
 - [Peergos](https://peergos.org/) - Secure and private space online where you can store, share and view your photos, videos, music and documents. Also includes a calendar, news feed, task lists, chat and email client. Open source and self-hostable.


### PR DESCRIPTION
Full disclosure: I'm the author of [bewCloud](https://bewcloud.com/).

bewCloud is a modern and simpler alternative to Nextcloud and ownCloud. It's AGPL-3.0 licensed, has reached over 1.1k stars in GitHub, and (apparently, since it's not possible to prove) has hundreds of deployments live at the moment.

The website also has no analytics.