### PR TITLE
Add SecureShare to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
 - [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
 - [dele-to](https://dele.to) - Open Source. Modern app to share sensitive credentials and secrets securely with client-side AES-256 encryption, zero-knowledge architecture, and automatic self-destruction.
+- [SecureShare](https://github.com/ekos-cyber/SecureShare-App) - Zero-knowledge, E2EE self-hosted platform for sharing sensitive data and secrets with automatic expiration and CLI support. Open-source.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Hello! I would like to propose adding **SecureShare-App** to the "Pastebin and Secret Sharing" section.

**SecureShare-App** aligns with your strict privacy guidelines:
- **Zero-Knowledge:** All encryption is performed locally using the WebCrypto API.
- **E2EE:** The server is a passive storage provider and has no access to keys or plain-text secrets.
- **Open Source:** Code is fully transparent and open for community audit.
- **No Tracking:** Zero user-tracking, analytics, or third-party cookies.
- **Security Bonus:** Offers a dedicated CLI to minimize the attack surface of modern browsers.

I have followed your template and ensured the entry is placed in the correct section. Thank you!