### PR TITLE
Add Vaulted to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,6 +1052,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin) - A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
 - [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
+- [Vaulted](https://www.vaulted.fyi) - Zero-knowledge encrypted secret sharing. AES-256-GCM encryption happens in the browser — the server never sees plaintext. Self-destructing links with configurable view limits and expiration. No account required.
 - [dele-to](https://dele.to) - Open Source. Modern app to share sensitive credentials and secrets securely with client-side AES-256 encryption, zero-knowledge architecture, and automatic self-destruction.
 
 [Back to top 🔝](#contents)


### PR DESCRIPTION
## What is Vaulted?

[Vaulted](https://www.vaulted.fyi) is a zero-knowledge encrypted secret sharing tool. It lets you create self-destructing links for sharing passwords, API keys, and other sensitive text.

## Why it fits this list

- **Client-side AES-256-GCM encryption** — all encryption/decryption happens in the browser using the Web Crypto API
- **Zero-knowledge architecture** — the encryption key lives only in the URL fragment (`#`), never sent to the server
- **No account required** — no signup, no tracking, no ads
- **Self-destructing links** — configurable view limits (1–10) and expiration (up to 30 days)
- **Passphrase protection** — optional additional layer of security
- **CLI tool** — available via npm for terminal-based workflows

## Section

Added to **Pastebin and Secret Sharing**, alphabetically between scrt.link and dele-to.