### PR TITLE
Add OpenHabitTracker to Notes and Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Notally](https://github.com/OmGodse/Notally) - A beautiful notes app (local only, no sync).
 - [Notesnook](https://notesnook.com/) - Open source zero knowledge private note taking.
 - [Obsidian](https://obsidian.md) - Obsidian is the private and flexible note‑taking app. Closed source but has no trackers (website / apps) and E2EE sync. 
+- [OpenHabitTracker](https://openhabittracker.net) - Free, open source and cross-platform. Take notes, plan tasks and track habits. All data stored locally or self-hosted via Docker.
 - [Quillpad](https://quillpad.github.io/) - Take beautiful markdown notes and stay organized with task lists. Fork of Quillnote.
 - [SiYuan](https://github.com/siyuan-note/siyuan) - A local-first personal knowledge management system.
 - [Standard Notes](https://standardnotes.org/) - A free, open-source, and completely encrypted notes app.


### PR DESCRIPTION
OpenHabitTracker is a free, open source, cross-platform habit tracker. All data stored locally or self-hosted via Docker. No accounts required. https://openhabittracker.net