### PR TITLE
Add Inkwell to Notes and Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Anytype](https://www.anytype.io/) - An open-source Notion alternative. E2EE, cloud and local network sync, can be self-hosted.
 - [AppFlowy](https://www.appflowy.io/) - Open Source Notion Alternative. You are in charge of your data and customizations.
 - [HedgeDoc](https://hedgedoc.org/) - Formerly CodiMD (community). An awesome platform to write and share markdown.
+- [Inkwell](https://github.com/4worlds4w-svg/inkwell) - A portable, offline-first Markdown editor. Zero telemetry, no cloud, no account, data stays local. Single exe, cross-platform.
 - [Joplin](https://github.com/laurent22/joplin) - Note taking and to-do application with synchronisation and encryption capabilities.
 - [Logseq](https://logseq.com/) - A privacy-first alternative to WorkFlowy.
 - [Memos](https://github.com/usememos/memos) - An open-source, self-hosted memo hub with knowledge management and socialization. 


### PR DESCRIPTION
Add [Inkwell](https://github.com/4worlds4w-svg/inkwell) to the Notes and Tasks section.

Inkwell is a portable, offline-first Markdown editor focused on privacy:

- **Zero telemetry** — no analytics, no tracking, no phone-home
- **No cloud, no account** — all data stays local on your machine
- **Single executable** (~3MB), no install required
- **Fully offline** — works without internet
- Built with Rust and Tauri v2
- Cross-platform: Windows, macOS, Linux
- Free to download and use

Placed alphabetically between HedgeDoc and Joplin.