### PR TITLE
Add Char to Notes and Tasks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 
 - [Anytype](https://www.anytype.io/) - An open-source Notion alternative. E2EE, cloud and local network sync, can be self-hosted.
 - [AppFlowy](https://www.appflowy.io/) - Open Source Notion Alternative. You are in charge of your data and customizations.
+- [Char](https://char.com) - Open-source AI notepad for meetings with local AI options and on-device storage.
 - [HedgeDoc](https://hedgedoc.org/) - Formerly CodiMD (community). An awesome platform to write and share markdown.
 - [Joplin](https://github.com/laurent22/joplin) - Note taking and to-do application with synchronisation and encryption capabilities.
 - [Logseq](https://logseq.com/) - A privacy-first alternative to WorkFlowy.


### PR DESCRIPTION
Added [Char](https://char.com) — open-source AI notepad for meetings with local AI options and on-device storage.

- Source: https://github.com/fastrepl/char
- License: GPL-3.0
- Website: https://char.com