### PR TITLE
Add Uruky to Search Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 - [DuckDuckGo](https://duckduckgo.com) - A privacy respecting search engine.
 - [Brave Search](https://search.brave.com) - A privacy respecting search engine with [its own independent index](https://brave.com/search-independence/).
 - [Qwant](https://www.qwant.com/) - A zero tracking search engine made and hosted in France, EU.
+- [Uruky](https://uruky.com/) - An ad-free, no-tracking search engine, focused on personalization, made and hosted in the EU.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Full disclosure: I'm one of two owners of the company that owns [Uruky](https://uruky.com/) (the other's my wife). I've built a lot of its technology.

While it's not "usual" open source, the code is eventually shared with customers and they can use it as they like, except for commercial purposes or sharing it with other people.

Hopefully it's an important option enough to be added to the list. We regularly talk about it as being a EU-based [Kagi](https://kagi.com/) alternative.

The website also has no analytics.