### PR TITLE
Add LazyFish to ChatGPT alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ When using cloud-based AI services, the data you input is often collected and st
 #### ChatGPT
 
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
+- [LazyFish](https://lazyfish.app) - Browser-based AI chat that runs LLMs entirely client-side via WebGPU. No installation, no accounts, no data uploads.
 - [llama.cpp](https://github.com/ggerganov/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.


### PR DESCRIPTION
## Summary
LazyFish is a privacy-first suite of browser tools that includes an AI chat feature running LLMs entirely client-side via WebGPU. No data leaves the user's device — there are no accounts, no uploads, no tracking, and no analytics. Unlike other entries in this section which require local installation, LazyFish runs directly in the browser with zero setup.

## Checklist
- [x] Privacy-oriented: 100% client-side, zero network dependencies
- [x] No trackers on project website
- [x] Free and open source
- [x] Follows entry format from Contributing.md