### PR TITLE
Add FileShot.io to File Management and Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ on the DMCrypt kernel module.
 - [Croc](https://github.com/schollz/croc) - Easily and securely send things from one computer to another.
 - [Dat-cp](https://github.com/tom-james-watson/dat-cp) - Copy files between hosts on a network using the peer-to-peer Dat network.
 - [Destiny](https://leastauthority.com/community-matters/destiny/) - Send files directly to the receiver in real-time. Developed for and with HROs as a free Privacy Enhancing Technology alternative.
+- [FileShot.io](https://fileshot.io) - Zero-knowledge encrypted file sharing with AES-256-GCM browser-side encryption. The server never sees your decryption keys. 50GB free, no account required.
 - [Gokapi](https://github.com/Forceu/Gokapi) - Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported.
 - [Lufi](https://framagit.org/fiat-tux/hat-softwares/lufi) - Let's Upload that FIle — File sharing software.
 - [Localsend](https://localsend.org/) - Share files to nearby devices. Free, open source, cross-platform.


### PR DESCRIPTION
## Description

Add [FileShot.io](https://fileshot.io) to the File Management and Sharing section.

## Why it belongs here

FileShot.io is a zero-knowledge, privacy-first file sharing platform:
- **AES-256-GCM browser-side encryption** — files are encrypted before upload, the server never sees decryption keys
- **Zero-knowledge architecture** — encryption keys live only in the URL fragment, never transmitted to the server
- **No account required** — 50GB free, share files immediately without signup
- **No tracking** — privacy-first by design, no analytics trackers on the website
- Password protection, expiry dates, and download limits available

The privacy model is verifiable: the encryption happens in the browser (inspectable in DevTools), and the server receives only ciphertext.