### PR TITLE
Add SaneHosts to Privacy Tools > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [SaneHosts](https://github.com/sane-apps/SaneHosts) - macOS hosts file manager for system-wide ad and tracker blocking. PolyForm Shield licensed (open source for personal use), no telemetry, no account required.
 
 ### Android
 


### PR DESCRIPTION
## What I'm adding
SaneHosts — a macOS hosts file manager for system-wide ad and tracker blocking via /etc/hosts.

## Why it fits
The Privacy Tools > Desktop section currently has 2 entries, both Linux-focused. SaneHosts fills the macOS gap — it blocks ads, trackers, and malware at the system level, reaching all apps, not just the browser.

## Privacy properties
- Your hosts data stays on your Mac
- No account required
- Source code: https://github.com/sane-apps/SaneHosts
- License: PolyForm Shield — source-available and free for personal use and experimentation; commercial use requires a license
- The public website uses disclosed aggregate traffic stats

Disclosure: I am the developer of SaneHosts.
