### PR TITLE
Add SaneClip to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,6 +1486,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 ## Utilities
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
+- [SaneClip](https://github.com/sane-apps/SaneClip) - macOS clipboard manager that keeps all history local. No cloud sync, no telemetry, no account required.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What I'm adding
SaneClip — a macOS clipboard manager where your clipboard history stays on your device.

## Why it fits
Clipboard data is uniquely sensitive — passwords, API keys, banking info, and private messages all pass through it. SaneClip keeps that history local instead of syncing it to our servers.

## Privacy properties
- Your clipboard history stays on your Mac by default
- No account required
- Source code: https://github.com/sane-apps/SaneClip
- License: PolyForm Shield — source-available and free for personal use and experimentation; commercial use requires a license
- The public website uses disclosed aggregate traffic stats

Disclosure: I am the developer of SaneClip.
