### PR TITLE
Add SaneBar to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,6 +1486,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 ## Utilities
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
+- [SaneBar](https://github.com/sane-apps/SaneBar) - macOS menu bar manager with no telemetry. Local-only alternative to Bartender.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What I'm adding
SaneBar — a macOS menu bar icon manager designed to work locally on your Mac.

## Why it fits
Bartender, the most popular macOS menu bar manager, was acquired in 2024 and started requiring an account with unclear data practices, raising community trust concerns. SaneBar is a local-first alternative with no account requirement and public source code.

## Privacy properties
- Settings stay on your Mac
- No account required
- Source code: https://github.com/sane-apps/SaneBar
- License: PolyForm Shield — source-available and free for personal use and experimentation; commercial use requires a license
- The public website uses disclosed aggregate traffic stats

Disclosure: I am the developer of SaneBar.
