### PR TITLE
Add SaneClick to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,6 +1486,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 ## Utilities
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
+- [SaneClick](https://github.com/sane-apps/SaneClick) - macOS Finder toolbar customizer. Fully local, no telemetry, no account required.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What I'm adding
SaneClick — a macOS Finder toolbar customizer that runs locally on your Mac.

## Why it fits
SaneClick adds custom actions to Finder without needing an account or cloud service. Your setup stays on your device.

## Privacy properties
- Your data stays on your Mac
- No account required
- Source code: https://github.com/sane-apps/SaneClick
- License: PolyForm Shield — source-available and free for personal use and experimentation; commercial use requires a license
- The public website uses disclosed aggregate traffic stats

Disclosure: I am the developer of SaneClick.
