### PR TITLE
Add Meeting Scheduling section with Tymeslot

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
     - [Video and Audio](#video-and-audio)
     - [Audio](#audio)
     - [Podcasts](#podcasts)
+- [Meeting Scheduling](#meeting-scheduling)
 - [Music Recognition (Shazam-like)](#music-recognition)
 - [Notes and Tasks](#notes-and-tasks)
 - [Office](#office)
@@ -894,6 +895,18 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Trilium Notes](https://github.com/zadam/trilium) - Build your personal knowledge base with Trilium Notes 
 - [Vikunja](https://vikunja.io) - The open-source to-do app to organize your life.
 - [YankNote](https://github.com/purocean/yn) - A Hackable Markdown Note Application for Programmers.
+
+[Back to top 🔝](#contents)
+
+## Meeting Scheduling
+
+⛔ **Avoid**
+
+- **Calendly** - Embeds tracking pixels on scheduling pages, collects invitee data beyond what's needed for scheduling, and shares it with third-party advertising partners.
+
+✅  **Instead use**
+
+- [Tymeslot](https://github.com/Tymeslot/tymeslot) - Open-source, self-hostable meeting scheduling platform. Guests book time without creating an account; hosts retain full control of their data.
 
 [Back to top 🔝](#contents)
 

--- a/README.md
+++ b/README.md
@@ -906,7 +906,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 
 ✅  **Instead use**
 
-- [Tymeslot](https://github.com/Tymeslot/tymeslot) - Source-available (Elastic License 2.0), self-hostable meeting scheduling platform. Guests book time without creating an account; hosts retain full control of their data.
+- [Tymeslot](https://github.com/Tymeslot/tymeslot) - Open-source (AGPL-3.0), self-hostable meeting scheduling platform. Guests book time without creating an account; hosts retain full control of their data.
 
 [Back to top 🔝](#contents)
 

--- a/README.md
+++ b/README.md
@@ -906,7 +906,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 
 ✅  **Instead use**
 
-- [Tymeslot](https://github.com/Tymeslot/tymeslot) - Open-source, self-hostable meeting scheduling platform. Guests book time without creating an account; hosts retain full control of their data.
+- [Tymeslot](https://github.com/Tymeslot/tymeslot) - Source-available (Elastic License 2.0), self-hostable meeting scheduling platform. Guests book time without creating an account; hosts retain full control of their data.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What

Adds a new **Meeting Scheduling** section as a privacy-respecting alternative to Calendly, with [Tymeslot](https://github.com/Tymeslot/tymeslot) as the first entry.

## Why Calendly belongs in Avoid

Calendly embeds tracking pixels on scheduling pages, collects invitee data beyond what scheduling requires, and shares it with third-party advertising partners.

## Why Tymeslot

- Open-source (AGPL-3.0)
- Self-hostable — hosts retain full control of their data
- Guests book time without creating an account
- Uses Umami (privacy-respecting, cookieless analytics) on its project site

Disclosure: I'm involved with the project, so this is a self-submission — happy to have it scrutinised.