### PR TITLE
Add ElectionDeflection - on-device SMS filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,11 @@ This section is dedicated to some tools that may help users analyze the privacy 
 - [Netguard](https://netguard.me/) - A simple way to block access to the internet per application.
 - [RethinkDNS + Firewall](https://github.com/celzero/rethink-app) - An open-source, no-root firewall and DNS changer, with anti-censorship capabilities for Android 6+.
 
+
+### iOS
+
+- [ElectionDeflection](https://github.com/MillerMedia/ElectionDeflection) - Open-source iOS SMS filter that blocks political and election text messages using on-device machine learning. All processing happens entirely on-device — no data ever leaves the phone. [App Store](https://apps.apple.com/us/app/electiondeflection/id6670375536)
+
 [Back to top 🔝](#contents)
 
 ## Remote Access and Control


### PR DESCRIPTION
## Add ElectionDeflection

**What**: An open-source iOS SMS filter that blocks political and election-related text messages.

**Privacy angle**: All message classification happens entirely on-device using Apple's
`ILMessageFilterExtension` and CoreML. No message content is ever transmitted to external
servers. The app cannot read, store, or share SMS content — this is enforced at the OS level
by Apple's sandboxing of message filter extensions.

- **Source**: https://github.com/MillerMedia/ElectionDeflection
- **App Store**: https://apps.apple.com/us/app/electiondeflection/id6670375536
- **License**: MIT
- **Platform**: iOS

The filtering model runs locally using CoreML, making it a fully private solution for
managing unwanted political text messages.

I added an **iOS** subsection under **Privacy Tools** to complement the existing Android section.

**Disclosure**: I am the maintainer of this project.