### PR TITLE
Add Measure.events — privacy-first analytics with MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - [Swetrix](https://swetrix.com) - Privacy-focused, fully cookieless and opensource (and selfhostable) web-analytics service.
 - [Umami](https://umami.is/) - A simple, fast, website analytics alternative to Google Analytics.
 - [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based tracking that works everywhere (web, command-line, email, etc). No account required. Developer friendly.
+- [Measure.events](https://measure.events) - Privacy-first, cookieless web analytics with a native MCP server — lets AI agents query your analytics data directly. No cookie banners required.
 - [Rybbit](https://rybbit.io) - Open-source and privacy-friendly alternative to Google Analytics that is 10x more intuitive.
 
 [Back to top 🔝](#contents)


### PR DESCRIPTION
## Summary

Adding [Measure.events](https://measure.events) to the Analytics section.

**Why it fits:**
- 🍪 Cookie-free — no consent banners required
- 🔒 Privacy-first — no PII collection, GDPR-compliant out of the box
- 🤖 Unique: ships with a native MCP server so AI agents can query your analytics directly (first analytics tool to do this)
- Lightweight tracking script (~1KB)
- No data sold to third parties

**What makes it different from other entries:**
The MCP server integration is novel — your Claude/Cursor/Windsurf AI agent can ask 'what are my top pages this week?' and get a structured answer. No competitor (Plausible, Fathom, etc.) has this.

**Links:**
- Marketing site: https://measure.events
- App: https://lets.measure.events
- MCP server repo: https://github.com/Turbo-Puffin/measure-mcp-server

I added it alphabetically between Matomo and Nullitics (under M), but happy to adjust placement per maintainer preference.