### PR TITLE
Add Fairlytics to Analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@
 - [Ackee](https://ackee.electerious.com/) - Self-hosted website analytics.
 - [Aptabase](https://aptabase.com) - Open-source, privacy-first and simple analytics for mobile and desktop apps.
 - [Cabin](https://withcabin.com) - Privacy-first, carbon conscious web analytics.
+- [Fairlytics](https://fairlytics.dev) - Privacy-first analytics with a 510-byte tracker script. No cookies, no consent banners, GDPR compliant. Free tier available.
 - [GoatCounter](https://www.goatcounter.com/) - Privacy aware, lightweight and open-source analytics platform.
 - [Matomo](https://matomo.org/) - Google Analytics alternative that protects your data and your customers' privacy.
 - [Nullitics](https://nullitics.com/) - Zero-effort open-source cheap analytics.


### PR DESCRIPTION
## Add Fairlytics

[Fairlytics](https://fairlytics.dev) is a privacy-first web analytics tool.

- **510-byte** gzipped tracker script (smallest in the category)
- No cookies of any kind
- No IP addresses stored
- No personal data collected
- Honors DNT and Global Privacy Control signals
- GDPR, CCPA, and ePrivacy compliant without consent banners
- Free tier for up to 10,000 page views/month
- EU-hosted (Supabase EU region)

Fairlytics is an alternative to Google Analytics for developers who want simple, privacy-respecting traffic insights.