### PR TITLE
Add CloakBin to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,7 @@ GNU/Linux is a family of free (as in freedom and as in free beer) and open sourc
 These tools are useful when sharing secrets, code snippets or any other kind of text with others in a private way.
 
 - [crypt.fyi](https://crypt.fyi) - Ephemeral zero-knowledge sensitive data sharing platform with web, cli, and chrome-extension clients
+- [CloakBin](https://cloakbin.com) - Open-source zero-knowledge encrypted pastebin with client-side AES-256-GCM encryption. Decryption key stays in URL fragment (#key), never sent to server. Supports syntax highlighting, burn-after-reading, custom expiry, and password protection.
 - [NoPaste](https://github.com/bokub/nopaste) - Open Source pastebin alternative that works with no database, and no back-end code. Instead, the data is compressed and stored entirely in the link that you share, nowhere else.
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin) - A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.


### PR DESCRIPTION
## What

Adds [CloakBin](https://cloakbin.com) to the **Pastebin and Secret Sharing** section.

## Why

CloakBin is an open-source zero-knowledge encrypted pastebin:
- **Client-side AES-256-GCM encryption** — all encryption runs in the browser before data reaches the server
- **Key in URL fragment** (`#key`) — browsers never send fragments to servers, so the server cannot decrypt pastes
- **Open source** — [github.com/Ishannaik/CloakBin](https://github.com/Ishannaik/CloakBin)
- Features: syntax highlighting (40+ languages), burn-after-reading, custom expiry, password protection

**Disclosure:** I am the developer of CloakBin.