### PR TITLE
Add PDFGem — privacy-first PDF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,8 +926,9 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Cryptpad](https://cryptpad.fr/) - Collaboration suite, encrypted and open-source.
 - [Etherpad](https://etherpad.org/) - Highly customizable open source online editor providing collaborative editing in really real-time.
 - [Fileverse](https://fileverse.io) - Fileverse is building healthier alternatives with self-sovereignty, privacy by design, and standards compliance at its core.
-	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 
+	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized.
  	- [dSheets](https://dsheets.new): decentralized alternative to Excel and Google Sheets.
+- [PDFGem](https://pdfgem.io/) - Free browser-based PDF tools (merge, split, compress, OCR, sign, convert, redact). All processing runs client-side via WebAssembly; files never leave the browser. No account required.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What

Adds [PDFGem](https://pdfgem.io) to the **Office** section.

## Why it belongs here

PDFGem is a free suite of 28 browser-based PDF tools that processes everything client-side:

- **No uploads**: files never leave the user's browser — all processing runs locally via WebAssembly (pdf-lib, pdf.js, Tesseract WASM)
- **No account required**: no signup, no login, no cookies
- **No tracking**: no analytics, no fingerprinting — privacy-first by design
- **Tools include**: merge, split, compress, convert (Word/Excel/PPT/images to PDF and back), OCR text extraction, digital signatures, form filling, redact sensitive content, rotate, reorder pages, and more
- **16 languages**: fully localized interface

All PDF manipulation happens in the browser tab. The server only delivers static HTML/JS/CSS — zero file processing on the backend.