### PR TITLE
Add Haveno DEX to Crypto Payments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 - [Monero](https://www.getmonero.org/) - Monero is cash for a connected world. It's fast, private, untraceable and secure.
 - Cash - Use person-to-person payments using physical notes and coins.
+- [Haveno](https://haveno.exchange) - Decentralized P2P exchange for trading Monero. No KYC, no central server, 2-of-3 multisig escrow. Open source (AGPL-3.0). Community instances include [RetosSwap](https://retoswap.com) and [DawnSwap](https://dawnswap.com).
 
 > [!WARNING]
 > [Bitcoin](https://bitcoin.org) is not anonymous nor private. Bitcoin is traceable, transparent and pseudonymous. For a basic introduction, [see aantonop's video](https://yewtu.be/watch?v=JN1Bowgcle8). More advanced users can watch this [Bitcoin privacy series](https://yewtu.be/watch?v=QEnL5k0R08w).


### PR DESCRIPTION
## What

Adds [Haveno](https://haveno.exchange) to the Crypto Payments section, positioned naturally alongside the Monero entry.

## Why it belongs here

Haveno is a decentralized, open-source P2P exchange built on Monero (AGPL-3.0, [GitHub](https://github.com/haveno-dex/haveno)). It is a fork of Bisq, redesigned specifically for XMR. Key privacy properties:

- **No KYC** — no account, no identity verification
- **No central server** — fully P2P, no single point of failure or surveillance
- **Non-custodial** — 2-of-3 multisig escrow; funds never leave the user's control
- **Open source** — AGPL-3.0, auditable by anyone

It is the primary tool for people who want to convert fiat to Monero privately, which makes it a direct complement to the Monero entry already in this section. Active community instances include [RetosSwap](https://retoswap.com) and [DawnSwap](https://dawnswap.com).

## Placement

Inserted after the `Cash` bullet, within the existing Crypto Payments section — right where a reader who just learned about Monero would look for a way to actually acquire it privately.