### PR TITLE
Add AbsentKey to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,7 @@ GNU/Linux is a family of free (as in freedom and as in free beer) and open sourc
 
 These tools are useful when sharing secrets, code snippets or any other kind of text with others in a private way.
 
+- [AbsentKey](https://absentkey.com) - Pick who gets your passwords and files, and set a timer for each person. If you go quiet, they get in when time runs out. Zero-knowledge, E2EE. ([Source](https://github.com/Absentkey/absentkey-mobile))
 - [crypt.fyi](https://crypt.fyi) - Ephemeral zero-knowledge sensitive data sharing platform with web, cli, and chrome-extension clients
 - [NoPaste](https://github.com/bokub/nopaste) - Open Source pastebin alternative that works with no database, and no back-end code. Instead, the data is compressed and stored entirely in the link that you share, nowhere else.
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin) - A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES.


### PR DESCRIPTION
AbsentKey is for sharing passwords and files with specific people.
Unlike Yopass/scrt.link/PrivateBin, it's not a one-time link. You pick
who gets access, set a waiting time per person, and approve or deny
their requests. If you go quiet, access unlocks automatically after
the timer.

Privacy:
- Zero-knowledge server never sees plaintext
- E2EE: XSalsa20-Poly1305, X25519 key exchange
- No analytics or tracking on the app/website
- Mobile source on GitHub: https://github.com/Absentkey/absentkey-mobile
- Privacy policy: https://absentkey.com/en/privacy-policy/