### PR TITLE
Add amneziawg-installer to VPNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1576,6 +1576,7 @@ Here are some open source and truly private (no personal data and/or credit card
 - [Mullvad VPN](https://mullvad.net)
 - [Proton VPN](https://protonvpn.com)
 - [SPN](https://safing.io/)
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - Self-hosted AmneziaWG 2.0 VPN for Ubuntu/Debian. DPI-resistant WireGuard fork with protocol obfuscation — no third-party servers, full control over your traffic.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
amneziawg-installer automates deployment of AmneziaWG 2.0 — a WireGuard fork with protocol-level obfuscation to bypass DPI censorship.

Privacy angle: unlike VPN providers, a self-hosted VPN means no third-party servers see your traffic. You control the server, the keys, and the configuration.

Open source (MIT), pure Bash, no external dependencies. Supports Ubuntu 24.04/25.10 and Debian 12/13.

Disclosure: I'm the author.