### PR TITLE
Add Parchment and ImageToolkit — privacy-first browser-based tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Fileverse](https://fileverse.io) - Fileverse is building healthier alternatives with self-sovereignty, privacy by design, and standards compliance at its core.
 	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 
  	- [dSheets](https://dsheets.new): decentralized alternative to Excel and Google Sheets.
+- [Parchment](https://dannycranmer.github.io/parchment/) - Free, privacy-first PDF tools (merge, split, compress, convert, watermark, sign). Runs entirely in the browser — no file uploads, no server processing.
 
 [Back to top 🔝](#contents)
 
@@ -1127,6 +1128,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [ImageToolkit](https://dannycranmer.github.io/imagetoolkit/) - Free, privacy-first image tools (compress, resize, convert, crop). Runs entirely in the browser — no file uploads, no server processing.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
## Summary

This PR adds two free, privacy-first browser-based tools:

- **[Parchment](https://dannycranmer.github.io/parchment/)** — PDF tools (merge, split, compress, convert, watermark, sign). Added to the **Office** section.
- **[ImageToolkit](https://dannycranmer.github.io/imagetoolkit/)** — Image tools (compress, resize, convert, crop). Added to the **Photo Editing and Management > Web** section.

Both tools run entirely in the browser with no file uploads and no server-side processing, making them strong privacy-respecting alternatives to cloud-based services like Adobe Acrobat, iLovePDF, or TinyPNG.

## Why these belong here

- All file processing happens client-side in the browser — nothing is uploaded to any server
- No tracking, no analytics, no accounts required
- Completely free with no usage limits
- Open source on GitHub
