### PR TITLE
Add DeepDNA to Fitness and Health — privacy-first DNA analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,9 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 ### Medical health
 - [Fasten](https://github.com/fastenhealth/fasten-onprem) - Fasten is an open-source, self-hosted, personal/family electronic medical record aggregator, designed to integrate with 1000's of insurances/hospitals/clinics.
 
+### DNA / Genetic Analysis
+- [DeepDNA](https://deepdna.ai) - European AI-powered DNA analysis platform. Upload raw data from 23andMe or AncestryDNA for health, nutrition, and pharmacogenomic insights. GDPR-compliant, EU-only servers, one-time payment, no subscriptions. You control when your data is deleted.
+
 [Back to top 🔝](#contents)
 
 ## Fonts


### PR DESCRIPTION
## What

Adds [DeepDNA](https://deepdna.ai) under **Fitness and Health > DNA / Genetic Analysis** as a privacy-respecting alternative to 23andMe and AncestryDNA.

## Why it belongs here

DNA data is among the most sensitive personal data. After the 23andMe breach (6.9M users affected), there's a clear need for privacy-first alternatives:

- **GDPR-compliant** — built and hosted entirely in the EU
- **EU-only servers** — data never leaves Europe
- **One-time payment (€29)** — no subscriptions, no data monetization
- **User-controlled deletion** — you decide when your data is removed
- **No third-party sharing** — your genetic data stays yours

## Disclosure

This PR is submitted by the DeepDNA team. We believe the project fits this list's mission of cataloging privacy-respecting alternatives to data-hungry services.