### PR TITLE
feat: add Rapid-MLX to AI/ChatGPT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - OpenAI-compatible local LLM inference server for Apple Silicon. Run AI models 100% locally with zero cloud data exposure, 2-4x faster than Ollama.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 


### PR DESCRIPTION
## What is Rapid-MLX?

[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an OpenAI-compatible local LLM inference server built specifically for Apple Silicon (M1/M2/M3/M4). It runs AI models 100% locally with zero cloud data exposure and is 2-4x faster than Ollama on the same hardware.

## Why it belongs in awesome-privacy

- **Zero cloud data exposure** — all inference runs on-device, no data ever leaves the machine
- **OpenAI-compatible API** — drop-in replacement, easy self-hosting
- **Apple Silicon optimized** — uses the MLX framework for maximum privacy + performance on Mac hardware
- **Apache-2.0 licensed** — fully open source

## Placement

Added to the **ChatGPT alternatives** subsection of the AI section, in alphabetical order between PasteGuard and Shimmy.