### PR TITLE
Add PiiBlocker to Artificial Intelligence section in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
+- [PiiBlocker](https://www.piiblock.com) - Free Chrome extension that detects and masks PII before it reaches ChatGPT, Claude, and Gemini. Runs 100% locally in the browser with zero data collection.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 


### PR DESCRIPTION
Adding PiiBlocker - a free Chrome extension that detects and masks personally identifiable information (PII) before it reaches AI chatbots like ChatGPT, Claude, and Gemini.

Why it fits this list:
- 100% local processing - no servers, no data collection
- Zero account required
- Detects 15+ PII types using NER + regex
- AES-256 encrypted mappings with auto-expiry
- Free and available on the Chrome Web Store

Website: https://www.piiblock.com
Chrome Web Store: https://chromewebstore.google.com/detail/privacyshield/nklghhkmhkmckonncilnaohlihfacoee
GitHub (issue tracker): https://github.com/piiblocker-coder/privacyshield