### PR TITLE
Add MapAtlas to Maps and Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,7 @@ With email aliases, you can finally create a different identity for each website
   - [OSMAnd](https://osmand.net/) - Android/iOS Navigation app using OSM. It is a feature-rich app with all you expect.
 - [Organic Maps](https://organicmaps.app/) - Great offline maps for hikers and cyclists.
 - [CoMaps](https://www.comaps.app/) - A community-led free & open source maps app based on OSM
+- [MapAtlas](https://mapatlas.eu) - European privacy-first mapping API offering geocoding, routing, and map tiles. EU-hosted, GDPR compliant, ISO 27001 certified, with no user tracking or IP logging.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adding MapAtlas as a privacy-respecting mapping alternative.

MapAtlas is a European mapping API that provides geocoding, routing, and map tiles without tracking users. All data stays on EU infrastructure.

Why it fits:
- Privacy-respecting alternative to Google Maps API / Mapbox
- EU-hosted (GDPR compliant by design)
- ISO 27001 certified
- No user IP addresses or session data stored
- No tracking
- Free tier available

Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V., the company behind MapAtlas.