### PR TITLE
Add Locally Uncensored to ChatGPT alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
+- [Locally Uncensored](https://github.com/PurpleDoubleD/locally-uncensored) - All-in-one local AI app combining uncensored chat, image generation, and video generation in a single privacy-focused UI. Uses Ollama and ComfyUI, runs 100% offline.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.


### PR DESCRIPTION
Added [Locally Uncensored](https://github.com/PurpleDoubleD/locally-uncensored) to the ChatGPT alternatives section.

It's an all-in-one local AI app that combines uncensored chat (via Ollama), image generation (via ComfyUI), and video generation in a single UI. Everything runs 100% offline with zero data collection - no cloud, no telemetry, no accounts needed. MIT licensed.