### PR TITLE
Add TouchBridge — local biometric auth for macOS, no cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [Owky](https://github.com/charlietango/owky) - Free and Open Source Two-Factor Authenticator for IOS users.
 - [🤖](#icons) [FreeOTPPlus](https://github.com/helloworld1/FreeOTPPlus) - Enhanced fork of FreeOTP-Android providing a feature-rich 2FA authenticator.
 - [🤖](#icons) [Authenticator Pro](https://github.com/jamie-mh/AuthenticatorPro) - Two-Factor Authentication (2FA) client for Android + Wear OS.
+- [TouchBridge](https://github.com/HMAKT99/UnTouchID) - Use your phone's fingerprint to authenticate on any Mac. Local BLE only — no cloud, no servers. Free alternative to $199 Touch ID keyboard. Works with iPhone, Android, or any browser.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds TouchBridge to the 2FA section.

TouchBridge uses your phone's biometric (Face ID/fingerprint) to authenticate on macOS — sudo, screensaver, etc. Completely local (BLE only), no cloud, no servers, no accounts. ECDSA P-256 with Secure Enclave. Free, MIT.

https://github.com/HMAKT99/UnTouchID