### PR TITLE
Add Paperweight to privacy tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [Paperweight](https://www.paperweight.email/) - Paperweight scans your inbox to map your digital footprint and helps take back control and manage your data.
 
 ### Android
 


### PR DESCRIPTION
Paperweight scans your inbox to map your digital footprint, then helps you take back control and delete your data. Local-first and open source.

Links
- https://www.paperweight.email/
- https://github.com/wslyvh/paperweight

Why it fits this list
- Local-first desktop App. No data ever leaves your device
- No tracking. No ads. No accounts.
- Fully open-source (GPLv3 license)
- Bulk unsubscribe from multiple mailing lists at once
- Find every company that has your data
- See which companies you use have been breached
- GDPR/data deletion request templates

Added under Privacy Tools.