### PR TITLE
Add Pilgrim to Fitness trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 - [🤖](#icons) [Fitotrack](https://codeberg.org/jannis/FitoTrack) - A privacy oriented fitness tracker for Android.
 - [🤖](#icons) [OpenTracks](https://github.com/OpenTracksApp/OpenTracks) - OpenTracks is a sport tracking application that completely respects your privacy.
 - [🤖](#icons) [Gadgetbridge](https://codeberg.org/Freeyourgadget/Gadgetbridge) - A free and cloudless replacement for your gadget vendors' closed source Android applications.
+- [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) - Privacy-first walking and meditation companion for iOS. On-device voice transcription, no accounts, no analytics, no cloud. Free and open source.
 
 ### Workout planners
 


### PR DESCRIPTION
## Add Pilgrim

[Pilgrim](https://pilgrimapp.org) is a privacy-first walking and meditation companion for iOS.

**Privacy credentials:**
- No accounts, no analytics, no telemetry, no cloud
- Voice transcription runs entirely on-device (WhisperKit)
- All data stays on the user's device — delete the app, data goes with it
- Privacy manifest declares exactly what's accessed and why
- Free, no subscriptions, no in-app purchases

**Open source:** [github.com/walktalkmeditate/pilgrim-ios](https://github.com/walktalkmeditate/pilgrim-ios) (GPLv3)

**App Store:** [apps.apple.com/app/pilgrim-mindful-walking/id6760921056](https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056)

Added to the **Fitness trackers** subsection under **Fitness and Health**.