### PR TITLE
Add Lockpaw to Privacy Tools > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard — lock and unlock your screen with a hotkey to keep your display private while AI agents or tasks keep running.
 
 ### Android
 


### PR DESCRIPTION
## Summary

Add [Lockpaw](https://github.com/sorkila/lockpaw) to the **Privacy Tools > Desktop** section.

Lockpaw is an open-source (MIT) macOS menu bar screen guard. Lock and unlock your screen with a hotkey to keep your display private while AI agents or background tasks keep running. It collects no data, has no network calls (except optional Sparkle auto-updates), and runs entirely locally.

- **GitHub:** https://github.com/sorkila/lockpaw
- **Homepage:** https://getlockpaw.com
- **License:** MIT
- **Stars:** 79+