### PR TITLE
Add Pilgrim - privacy-first walking & meditation app (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 - [🤖](#icons) [Fitotrack](https://codeberg.org/jannis/FitoTrack) - A privacy oriented fitness tracker for Android.
 - [🤖](#icons) [OpenTracks](https://github.com/OpenTracksApp/OpenTracks) - OpenTracks is a sport tracking application that completely respects your privacy.
 - [🤖](#icons) [Gadgetbridge](https://codeberg.org/Freeyourgadget/Gadgetbridge) - A free and cloudless replacement for your gadget vendors' closed source Android applications.
+- [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) - Privacy-first walking and meditation companion for iOS. Zero cloud, no accounts, no analytics, no telemetry. Voice transcription runs entirely on-device via WhisperKit. Ships with an Apple privacy manifest. GPLv3.
 
 ### Workout planners
 


### PR DESCRIPTION
## Summary

- Adds [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) to the **Fitness trackers** subsection under **Fitness and Health**
- Pilgrim is a privacy-first walking and meditation companion for iOS

## Why it belongs here

Pilgrim is built with a zero-cloud architecture:

- **No accounts** -- no sign-up, no login, no user identity
- **No analytics SDK** -- no Firebase, no Mixpanel, no telemetry of any kind
- **No cloud storage** -- all walk data, recordings, and transcriptions stay on-device
- **On-device voice transcription** -- uses [WhisperKit](https://github.com/argmaxinc/WhisperKit) for fully local speech-to-text, nothing sent to any server
- **Apple privacy manifest** -- ships `PrivacyInfo.xcprivacy` declaring exactly which APIs are used and why
- **Open source** -- GPLv3 licensed, full source available
- **Free** -- no in-app purchases, no subscriptions

App Store: https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056

## Checklist

- [x] Clear privacy-oriented policy (zero cloud, on-device only)
- [x] No user-tracking on project website
- [x] Open source (GPLv3)
- [x] Follows existing entry format
- [x] Added to appropriate section (Fitness and Health > Fitness trackers)