### PR TITLE
Add Kviskr to Speech to Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [Kviskr](https://kviskr.no) - macOS menu bar app for speech-to-text using whisper.cpp with CoreML. All transcription is processed locally on-device, no data is sent to the cloud. Specialized for Norwegian with NB-Whisper.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
## Summary

- Adds [Kviskr](https://kviskr.no) to the **Speech to Text > Apps and services** section
- Kviskr is a macOS menu bar app for speech-to-text that processes all transcription locally on-device using whisper.cpp with CoreML -- no data is sent to the cloud
- Specialized for Norwegian with NB-Whisper, free, macOS 14+, Apple Silicon

## Checklist

- [x] Entry follows existing format (tab-indented, link + description)
- [x] Alphabetically sorted within the subsection
- [x] Privacy-focused: all processing happens locally on-device