### PR TITLE
Add Convert.rocks — client-side image converter (no upload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ on the DMCrypt kernel module.
 - [Portal](https://github.com/SpatiumPortae/portal) - A command-line file transfer utility for sending encrypted files from any computer to another.
 - [QRcp](https://github.com/claudiodangelis/qrcp) - Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
 - [Send](https://gitlab.com/timvisee/send) - Simple, private file sharing. (Mozilla Send Fork)
+- [convert.rocks](https://www.convert.rocks) - Client-side file converter (HEIC, WebP, AVIF, PNG). All processing in browser, no files uploaded to any server.
 - [Sharik](https://github.com/marchellodev/sharik) - Sharik works with Wi-Fi connection or Tethering (Wi-Fi Hotspot). No internet connection needed. Available for Android, iOS, Linux, MacOS & Windows.
 - [Snapdrop](https://github.com/RobinLinus/snapdrop) - A Progressive Web App for local file sharing inspired by Apple's Airdrop.
 - [Winden](https://winden.app/) - A convenient version of Magic Wormhole you can use from within your browser. No need to install an app.


### PR DESCRIPTION
## What is Convert.rocks?

[Convert.rocks](https://www.convert.rocks) is a free, privacy-first image converter that runs **entirely in the browser** using WebAssembly (WASM). No files are ever uploaded to any server — all processing happens client-side.

### Supported formats
- HEIC / HEIF to JPG/PNG
- WebP to JPG/PNG
- Live Photos to JPG

### Why it fits this list
- **Privacy by design**: Zero server involvement. Files never leave the user's device.
- **No tracking**: No analytics or user tracking on the site.
- **Open source**: Source code is available at [github.com/glebr2d2/heicconverter](https://github.com/glebr2d2/heicconverter).
- **Chrome extension**: Also available as a [Chrome extension](https://chromewebstore.google.com/detail/heic-to-png-converter/hlkifcnbooeflbhjbghkgbmjpalnfpia) for quick conversions.

### Where in the list
Added under **Photo Editing and Management > Web**, alongside miniPaint (another browser-based tool with no server uploads).