### PR TITLE
Add Beam — privacy-first cookie-free web analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@
 - [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based tracking that works everywhere (web, command-line, email, etc). No account required. Developer friendly.
 - [Rybbit](https://rybbit.io) - Open-source and privacy-friendly alternative to Google Analytics that is 10x more intuitive.
 
+- [Beam](https://beam.keylightdigital.com/) - Privacy-first, cookie-free web analytics for websites. No personal data stored, GDPR compliant, no consent banner required. Open-source tracking script, free tier available. ([Demo](https://beam.keylightdigital.com/demo), [Source](https://github.com/scobb/beam.js))
+
 [Back to top 🔝](#contents)
 
 ## Android

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 ✅  **Instead use**
 - [Ackee](https://ackee.electerious.com/) - Self-hosted website analytics.
 - [Aptabase](https://aptabase.com) - Open-source, privacy-first and simple analytics for mobile and desktop apps.
+- [Beam](https://beam.keylightdigital.com/) - Lightweight, cookie-free, GDPR-compliant web analytics. Open-source alternative to Google Analytics running on Cloudflare's edge network.
 - [Cabin](https://withcabin.com) - Privacy-first, carbon conscious web analytics.
 - [GoatCounter](https://www.goatcounter.com/) - Privacy aware, lightweight and open-source analytics platform.
 - [Matomo](https://matomo.org/) - Google Analytics alternative that protects your data and your customers' privacy.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@
 - [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based tracking that works everywhere (web, command-line, email, etc). No account required. Developer friendly.
 - [Rybbit](https://rybbit.io) - Open-source and privacy-friendly alternative to Google Analytics that is 10x more intuitive.
 
-- [Beam](https://beam.keylightdigital.com/) - Privacy-first, cookie-free web analytics for websites. No personal data stored, GDPR compliant, no consent banner required. Open-source tracking script, free tier available. ([Demo](https://beam.keylightdigital.com/demo), [Source](https://github.com/scobb/beam.js))
+- [Beam](https://beam-privacy.com/) - Privacy-first, cookie-free web analytics for websites. No personal data stored, GDPR compliant, no consent banner required. Open-source tracking script, free tier available. ([Demo](https://beam-privacy.com/demo), [Source](https://github.com/scobb/beam.js))
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Add Beam Analytics

Adding [Beam](https://beam-privacy.com/) to the Analytics section as a privacy-friendly alternative to Google Analytics.

**Why it belongs here:**
- No cookies, no personal data stored at all
- GDPR compliant — no consent banner required by law
- Cookie-free tracking via hashed non-PII signals only
- Sub-2KB open-source tracking script: https://github.com/scobb/beam.js
- Free tier available, no lock-in
- Managed service (no self-hosting infra to maintain)

**Live product:** https://beam-privacy.com/
**Live demo:** https://beam-privacy.com/demo
**Open-source tracking script:** https://github.com/scobb/beam.js