### PR TITLE
Add TiredVPN to VPNs section as self-hosted alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ Here are some open source and truly private (no personal data and/or credit card
 - [Mullvad VPN](https://mullvad.net)
 - [Proton VPN](https://protonvpn.com)
 - [SPN](https://safing.io/)
+- [TiredVPN](https://github.com/tiredvpn/tiredvpn) - Self-hosted, DPI-resistant VPN with 20+ obfuscation strategies. Designed for censored networks. No accounts or registration needed. AGPL-3.0.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What

Adding TiredVPN as a self-hosted VPN option in the VPNs section.

## Why it fits

The current VPNs section lists privacy-focused VPN services. TiredVPN complements them as a self-hosted option for users who:

- Want full control over their VPN infrastructure
- Need to bypass DPI in censored countries (Russia, China, Iran)
- Don't want to trust a third-party service

## Key privacy properties

- Fully self-hosted: you run your own server
- No accounts, no registration, no personal data required
- No logs by design
- Open source: AGPL-3.0, full code audit possible
- 20+ obfuscation strategies to avoid traffic analysis
- Android and Linux clients available

## Links

- https://github.com/tiredvpn/tiredvpn
- https://github.com/tiredvpn/tiredvpn-android