### PR TITLE
Add Guard to Privacy Tools (Desktop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [Guard](https://github.com/FaisalFehad/Guard) - Camera access monitor for macOS that freezes processes before they can read a frame until you approve.
 
 ### Android
 


### PR DESCRIPTION
[Guard](https://github.com/FaisalFehad/Guard) — Camera access monitor for macOS.

Guard monitors the camera via CoreMediaIO and freezes any process that tries to access it (SIGSTOP) until the user explicitly approves. Fully local, no network calls, no telemetry, no accounts.

- **Homepage:** https://guard-app.net
- **Repository:** https://github.com/FaisalFehad/Guard
- **License:** MIT
- **Privacy policy:** Zero data collection. Everything runs locally.