### PR TITLE
Add Mirlo to Browser Addons > Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1619,6 +1619,7 @@ Please read about what the addon does before installing. If you don't understand
 
 #### Useful Tools
 - [Single File](https://github.com/gildas-lormeau/SingleFile) - Save a faithful copy of an entire web page in a single HTML file so you can use it offline.
+- [Mirlo](https://github.com/BoxcarsAI/mirlo) - Learn a language while you browse — replaces words on pages with the language you're trying to learn. Translations run on Chrome's new on-device Translator API. Nothing leaves your browser.
 
 ### Browser Sync
 - [xBrowserSync](https://www.xbrowsersync.org/) - Browser syncing as it should be: secure, anonymous and free!


### PR DESCRIPTION
Mirlo is an open-source Chrome extension for language learning. It replaces words on web pages with the language you're trying to learn — translations run entirely on-device using Chrome's Translator API. No servers, no accounts, no data collection.

I placed it under Browser Addons > Useful Tools since there's no Language Learning section. Happy to move it if there's a better fit.

- Repo: https://github.com/BoxcarsAI/mirlo
- License: MIT
- Chrome Web Store: https://chromewebstore.google.com/detail/mirlo-%E2%80%94-language-learning/bolaihmnmcaedodmcempenkddbkolaih
- Privacy policy: https://www.boxcars.ai/mirlo-privacy-policy/