### PR TITLE
Add SammaPix — privacy-first browser-based image toolkit (27 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [SammaPix](https://www.sammapix.com) - Free, privacy-first image toolkit with 27 browser-based tools (compress, resize, convert, AI background removal, EXIF removal, passport photos). All processing runs client-side via Canvas API and WebAssembly — images never leave your device. No signup required.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
## SammaPix

[SammaPix](https://www.sammapix.com) is a free, privacy-first image toolkit with **27 browser-based tools**.

### Why it fits this list

- **100% client-side** — all processing runs in the browser via Canvas API and WebAssembly
- **Zero uploads** — images never leave the user's device
- **Zero cookies, zero tracking** — no analytics on the free tier
- **No signup required** — every tool works immediately
- **EXIF/GPS removal** — built-in metadata stripping for photo privacy

### Added to

**Photo Editing and Management > Web** — alongside miniPaint.

### Tools include

Compress, resize, convert (HEIC/WebP/AVIF/JXL), AI background removal (RMBG-1.4 via WASM), passport photos (140+ countries), AI rename, batch watermark, duplicate finder, EXIF/GPS metadata removal, and more.

Website: https://www.sammapix.com