### PR TITLE
Add MirrorMask to Privacy Tools > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [MirrorMask](https://mirrormask.app) - macOS app that reshapes your algorithmic profile across Google, YouTube, Facebook, and Reddit by automating realistic browsing activity under configurable personas. Makes ad-targeting data less accurate without blocking. Closed-source.
 
 ### Android
 


### PR DESCRIPTION
MirrorMask is a macOS app that takes a different approach to privacy: instead of blocking tracking, it reshapes what platforms think you're interested in by automating realistic browsing activity under configurable personas.

- Browses as chosen personas across Google, YouTube, Facebook, Reddit
- Real Chrome sessions via Playwright (not headless/fake traffic)
- Before/after Google Ad Center scraping shows profile changes
- Published 5-day controlled experiment with proof data: https://nanobuilds.substack.com/p/how-fast-can-you-reshape-what-google
- 100% local, no cloud
- macOS 14+, Swift + TypeScript
- Closed-source

Website: https://mirrormask.app