### PR TITLE
Add Anytools to Developer Tools — privacy-respecting online dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,12 @@ Opt for open-source and P2P alternatives that prioritize data privacy, eliminate
 ## Developer Tools
 - [Beekeeper Studio](https://www.beekeeperstudio.io) - Open Source SQL Editor and Database Manager with a privacy commitment in their mission statement.
 
+### Online Dev Tools
+⛔ Most online developer tools (JSON formatters, JWT decoders, Base64 encoders, password generators) send your input to a server for processing. Your production tokens, API responses, and generated passwords end up in third-party logs.
+
+✅ Instead use
+- [Anytools](https://anytools.io) - 89+ browser-based developer, design, and utility tools. All processing is client-side — zero outbound requests after page load. No accounts, no analytics, no third-party scripts, self-hosted fonts. Verifiable by checking DevTools Network tab.
+
 ### IDEs
 ⛔ Avoid using privative IDEs that are full of trackers and telemetry.
 


### PR DESCRIPTION
Adds [Anytools](https://anytools.io) under Developer Tools > Online Dev Tools.

Most online developer tools (JSON formatters, JWT decoders, password generators) send user input to servers for processing. Anytools is a privacy-respecting alternative:

- **89+ browser-based tools** — dev tools, design tools, calculators
- **100% client-side** — zero outbound requests after page load
- **No accounts, no analytics, no third-party scripts**
- **Self-hosted fonts** — no Google Fonts requests
- **Verifiable** — open DevTools Network tab while using any tool

This fills a gap in the list — there was no section covering online developer utilities, which are widely used and frequently privacy-hostile.