### PR TITLE
Add Tax Filing category with FreeFile ITR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,10 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Sure](https://github.com/we-promise/sure) - Open Source and secure OS for your personal finances. Community maintained fork of the archived [Maybe](https://github.com/maybe-finance/maybe) project.
 - [ezBookkeeping](https://ezbookkeeping.mayswind.net/) - A lightweight, self-hosted personal finance app with a user-friendly interface and powerful bookkeeping features.
 
+### Tax Filing
+
+- [FreeFile ITR](https://github.com/rohitthink/freefile) - Free, privacy-first income tax return filing app for Indian freelancers. All financial data stored locally on device, no accounts, no telemetry. Imports bank statements from major Indian banks, computes tax under both regimes, and files directly on the official tax portal.
+
 ### Budget Management
 - [Budget Zen](https://budgetzen.net) - Simple and Encrypted Budget Management.
 - [ProExpense](https://github.com/arduia/ProExpense/) - A simple free finance note to safely record daily expenses.


### PR DESCRIPTION
Adding **FreeFile ITR** under a new **Tax Filing** subsection in Personal Finances.

**Project:** https://github.com/rohitthink/freefile
**License:** AGPL-3.0

## Why it belongs in awesome-privacy

FreeFile is a privacy-first income tax return filing app for Indian freelancers. Every design decision prioritizes user privacy:

- **Local-first:** All financial data (transactions, income, deductions, TDS) stored locally in SQLite on the user's device. No backend database stores user data.
- **No accounts:** No sign-up, no user accounts.
- **No telemetry, no tracking, no analytics.**
- **Credentials never touch the app:** When filing on incometax.gov.in, the user enters credentials directly in the official portal window via Playwright automation.
- **Open source tax engine:** Users can audit the computation logic for correctness and any hidden data exfiltration.

This fills a real gap in the privacy ecosystem — most "free" Indian tax filing apps monetize user financial data, and the official portal requires a CA for non-trivial filings (₹3,000-5,000 per return).

I added a new **Tax Filing** subsection under Personal Finances since "Full Featured Financial Management" is more about budget tracking than tax filing.

Thanks for maintaining this list!