### PR TITLE
Add Ghoststrip to Photo Editing and Management (Web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [Ghoststrip](https://ghoststrip.com) - Browser-based EXIF and metadata stripper for images, PDFs and Office documents. No upload — everything stays in your browser.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
Adding Ghoststrip to the Web section under Photo Editing and Management, alongside miniPaint.

- Client-side only — no file upload, no server, no tracking
- Strips EXIF, GPS, author, timestamps from JPEG, PNG, AVIF, HEIC, PDF, DOCX, XLSX, PPTX
- Also removes C2PA/AI credentials (DALL-E, Firefly, Stable Diffusion)
- Free to use at ghoststrip.com