### PR TITLE
Add DictatorFlow and Text-Generator.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
+- [Text-Generator.io](https://text-generator.io) - Privacy-first unified text, vision, and speech API with support for local and self-hosted model inference.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 
 #### AI Coding
@@ -287,6 +288,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [DictatorFlow](https://dictatorflow.com) - Offline voice dictation and voice-command editing desktop app with local processing and no cloud dependency.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
## Summary
- Adds [DictatorFlow](https://dictatorflow.com) to the **Artificial Intelligence > Speech to Text > Apps and services** section — offline voice dictation and voice-command editing desktop app with local processing and no cloud dependency.
- Adds [Text-Generator.io](https://text-generator.io) to the **Artificial Intelligence > ChatGPT** section — privacy-first unified text, vision, and speech API with support for local and self-hosted model inference.

Both entries are placed in alphabetical order within their respective sections.

## Test plan
- [ ] Verify links resolve correctly
- [ ] Confirm formatting matches existing entries (indentation, dash style)
- [ ] Verify alphabetical ordering is maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)