### PR TITLE
Add stratif.io to Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [Pirsch](https://pirsch.io/) - Pirsch is a simple, privacy-friendly, open-source alternative to Google Analytics — lightweight, cookie-free and easily integrated into any website or backend.
 - [Plausible](https://plausible.io/) - Simple and privacy-friendly alternative to Google Analytics.
 - [Shynet](https://github.com/milesmcc/shynet) - Modern, privacy-friendly, and detailed web analytics that works without cookies or JS.
+- [stratif.io](https://stratif.io) - Self-hosted, open-source product analytics that runs directly on your DuckDB, Postgres, Snowflake, or ClickHouse warehouse.
 - [Swetrix](https://swetrix.com) - Privacy-focused, fully cookieless and opensource (and selfhostable) web-analytics service.
 - [Umami](https://umami.is/) - A simple, fast, website analytics alternative to Google Analytics.
 - [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based tracking that works everywhere (web, command-line, email, etc). No account required. Developer friendly.


### PR DESCRIPTION
Adds stratif.io to the Analytics section.

stratif.io is an open-source (Apache-2.0), self-hosted product analytics tool. It runs directly on your existing SQL warehouse (DuckDB, Postgres, Snowflake, ClickHouse, Databricks) — no ingestion pipeline, no tracking SDK, and no copy of your events in any third-party SaaS.

Privacy notes (per the contribution guidelines):
- Own-your-data: fully self-hosted; events never leave the operator's infrastructure.
- No user-tracking on the project website: stratif.io uses Umami (which is already listed in this Analytics section) for site analytics.
- Open source code: Apache-2.0, https://github.com/stratif-io/stratif.io