### PR TITLE
Add Metadata Remover to EXIF section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1157,6 +1157,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Pocket Paint](https://github.com/Catrobat/Paintroid) - The standard image manipulation app for Catroid.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Remove Exif data from pictures before sharing them.
 - [ImagePipe](https://codeberg.org/Starfish/Imagepipe) - Reduces image size and removes exif-tags when sharing images on android devices.
+- [Metadata Remover](https://metadatacleaner.app) - Strip GPS, EXIF & AI metadata from images, video, and audio directly in your browser. No uploads, no server, 100% client-side.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
metadatacleaner.app is a browser-based tool that strips GPS, EXIF, and AI metadata from images, video, and audio. It runs 100% client-side — no uploads, no server. Available as a Chrome extension and web app. This adds a web/browser alternative alongside the existing Android apps in this section.