### PR TITLE
Add Flowvault to Notes and Tasks and Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Remember: Without strong encryption, you will be spied on systematically by lots
 
 - [Veracrypt](https://www.veracrypt.fr/en/Home.html) - VeraCrypt is a free open source disk encryption software for Windows, macOS and Linux.
 - [Shufflecake](https://shufflecake.net/index.html) - Free open source, plausible deniability for multiple hidden filesystems on Linux
+- [Flowvault](https://flowvault.flowdesk.tech) - Zero-knowledge encrypted browser notepad with plausible deniability. One URL can hide multiple notebooks behind different passwords, with trusted handover and time-locked notes.
 - [Hat.sh](https://hat.sh/) - A Free, Fast, Secure and Serverless File Encryption.
 - [Cryptomator](https://cryptomator.org/) - Cryptomator encrypts your data quickly and easily. Afterwards you upload them protected to your favorite cloud service.
 - [Stegcloak](https://stegcloak.surge.sh/) - Hide secrets with invisible characters in plain text securely using passwords.
@@ -895,6 +896,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 
 - [Anytype](https://www.anytype.io/) - An open-source Notion alternative. E2EE, cloud and local network sync, can be self-hosted.
 - [AppFlowy](https://www.appflowy.io/) - Open Source Notion Alternative. You are in charge of your data and customizations.
+- [Flowvault](https://flowvault.flowdesk.tech) - Zero-knowledge encrypted browser notepad with plausible deniability. One URL can hide multiple notebooks behind different passwords, with trusted handover and time-locked notes.
 - [HedgeDoc](https://hedgedoc.org/) - Formerly CodiMD (community). An awesome platform to write and share markdown.
 - [Joplin](https://github.com/laurent22/joplin) - Note taking and to-do application with synchronisation and encryption capabilities.
 - [Logseq](https://logseq.com/) - A privacy-first alternative to WorkFlowy.


### PR DESCRIPTION
Hi — adding Flowvault to two sections, following the contributing guide.

**What it is:** [Flowvault](https://flowvault.flowdesk.tech) is a zero-knowledge
encrypted browser notepad with plausible deniability — one URL can hide
multiple notebooks behind different passwords. Source code is public and
AGPL-3.0-compatible (licensed under the Flowvault repo's LICENSE).

**Where I added it:**

- **Notes and Tasks** — between AppFlowy and HedgeDoc (alphabetical).
- **Encryption** — directly after Shufflecake, since both offer plausible
  deniability (Shufflecake for hidden filesystems, Flowvault for a browser
  notepad).

**Requirements checklist (from `misc/Contributing.md`):**

- [x] Clear privacy-oriented / own-your-data policy — ciphertext-only storage,
      no account system, no password reset. See
      https://flowvault.flowdesk.tech/security
- [x] No user tracking on the project website — no analytics, no third-party
      scripts, no cookies beyond what the app needs to function.
- [x] Open source — https://github.com/flowdesktech/flowvault

**Crypto stack (for transparency):** Argon2id KDF → AES-256-GCM sealing,
all client-side. Time-locked notes use drand/tlock.

Happy to tweak the wording or drop one of the two sections if you'd prefer a
single entry.