### PR TITLE
Add Voidly Messenger — E2E PWA with PQ hybrid, deniable auth, federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ No single point of control or failure. A decentralized network operated by diffe
 - [Session](https://getsession.org/) - Extreme focus on privacy and anonymity. Blockchain technology.
 - [SimpleX Chat](https://simplex.chat/) - The first chat platform that is 100% private by design - it has no access to your connection graph
 - [Status](https://status.im/) - Status is a secure messaging app, crypto wallet, and Web3 browser built with state of the art technology.
+- [Voidly Messenger](https://msg.voidly.ai) - E2E-encrypted PWA (no install) with Signal Protocol (Double Ratchet + X3DH) plus ML-KEM-768 post-quantum hybrid key exchange, deniable authentication, sealed sender, message padding, metadata-stripping relay, and federation. Runs entirely client-side — server never sees plaintext.
 
 ### Centralized
 The service is in charge of running the servers that allow users to communicate. Single point of failure and control, but still 100% safe and trustworthy if the protocols and code are open and audited.


### PR DESCRIPTION
Adds [Voidly Messenger](https://msg.voidly.ai) to the **Instant Messaging → Decentralized** section — an E2E-encrypted messaging Progressive Web App that runs entirely in-browser with no install.

**Crypto stack:** Signal Protocol (Double Ratchet + X3DH) for forward/post-compromise secrecy, ML-KEM-768 post-quantum hybrid key exchange (NIST FIPS 203) for harvest-now-decrypt-later resistance, deniable authentication via HMAC (rather than signatures), sealed sender, message padding, and a metadata-stripping relay with federation. All cryptography is client-side — the relay (Cloudflare Worker) never sees plaintext, sender, thread, or message type.

**PWA advantage:** Nothing to install, no app-store dependency, open in a browser on any device — useful when the target audience lives under censorship and can't sideload apps. Identity is a user-generated `did:voidly` key with exportable credentials. Maintainer: @EmperorMew.