### PR TITLE
Add KeyboardTester.click WebRTC leak detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1655,3 +1655,4 @@ Certainly! Here's the formatted table:
 | 🤖    | Android Only. |
 
 [Back to top 🔝](#contents)
+- [KeyboardTester.click WebRTC Leak Test](https://keyboardtester.click/webrtc-leak-test.php) - Free browser-based WebRTC IP leak detector via STUN. Reports public IP, local IPs, IPv6 leaks. Open source.


### PR DESCRIPTION
Adds a free WebRTC IP leak detector to the list:

**WebRTC Leak Test** (https://keyboardtester.click/webrtc-leak-test.php) - Free, browser-based WebRTC leak detector that reports public IP, local IPs, and IPv6 addresses via STUN. Helps verify VPN / privacy setups.

- Works in any modern browser
- Nothing uploaded
- Open source: https://github.com/nasirazizawan009/keyboardtester-click