### PR TITLE
Add Maskmail to Email Alias Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ With email aliases, you can finally create a different identity for each website
 
 - [SimpleLogin](https://github.com/simple-login/app)
 - [AnonAddy](https://github.com/anonaddy/anonaddy)
+- [Maskmail](https://maskmail.io)
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds [Maskmail](https://maskmail.io) to the **Email Alias Services (Anonymous Forwarding)** section.

Maskmail is a hosted email mask service. Users create a unique mask per signup, forward what matters to their real inbox, and disable any abused mask instantly. Supports custom domains, anonymous replies, and a browser extension.

### Affiliation
I work on Maskmail.

### Note
The existing entries in this section link to GitHub repositories of self-hostable services. Maskmail is hosted only (closed source), so the link points to the homepage. Happy to move/remove if that doesn't match the intended scope of the section.