### PR TITLE
Add FastFileLink CLI (ffl) in File Sharing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ on the DMCrypt kernel module.
 - [Croc](https://github.com/schollz/croc) - Easily and securely send things from one computer to another.
 - [Dat-cp](https://github.com/tom-james-watson/dat-cp) - Copy files between hosts on a network using the peer-to-peer Dat network.
 - [Destiny](https://leastauthority.com/community-matters/destiny/) - Send files directly to the receiver in real-time. Developed for and with HROs as a free Privacy Enhancing Technology alternative.
+- [FastFileLink (ffl)](https://github.com/nuwainfo/ffl) - A privacy-first CLI for secure P2P file/folder sharing via HTTPS, featuring E2EE, password protection, and Tor support.
 - [Gokapi](https://github.com/Forceu/Gokapi) - Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported.
 - [Lufi](https://framagit.org/fiat-tux/hat-softwares/lufi) - Let's Upload that FIle — File sharing software.
 - [Localsend](https://localsend.org/) - Share files to nearby devices. Free, open source, cross-platform.


### PR DESCRIPTION
Hi! I'd like to propose adding **FastFileLink (ffl)** to the "File Management and Sharing" section. 

`ffl` is an open-source, privacy-first CLI tool that turns any local file or folder into a secure, sharable HTTPS link. 
GitHub: https://github.com/nuwainfo/ffl

I believe it perfectly aligns with the core values of the `awesome-privacy` list because its entire architecture is built around data minimization and zero-trust principles.

Here is a quick summary of its Security & Privacy highlights:

- **Data Never Rests (P2P):** Transfers happen directly between peers (WebRTC). Files are never stored on third-party cloud servers.
- **End-to-End Encryption (E2EE):** Users can easily enable E2EE for sensitive files. When enabled, key exchange happens strictly between peers, meaning even if a transfer falls back to an HTTPS relay, the server remains "blind" and only sees zero-knowledge encrypted blobs.
- **Extreme Privacy Mode (Tor):** For users requiring maximum IP-level anonymity, `ffl` supports Tor routing. To prevent IP leaks, enabling Tor automatically disables WebRTC and **strictly enforces E2EE**.
- **Layered, Account-less Verification:** `ffl` requires no accounts. To ensure extreme two-way privacy, users can stack verification methods—such as combining one-time pickup codes or long-term RSA Public Keys (`.fflpub`) with HTTP passwords. 
- **Verifiable Integrity:** Built-in zero-overhead Blake2b checksums guarantee that files are not tampered with or corrupted in transit.

I have formatted the entry according to the contributing guidelines and placed it in alphabetical order. Please let me know if you need any adjustments or further details. 

Thank you for maintaining this awesome list!