### PR TITLE
Add Off Grid (on-device mobile LLM app) to AI > ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
+- [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) - 100% on-device LLM app for iOS/Android via llama.cpp. Runs Llama, Qwen, Gemma, Phi, DeepSeek with voice (Whisper), vision, image gen (Stable Diffusion), and tool calling — all offline, MIT-licensed.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) to **Artificial Intelligence > ChatGPT**.

Off Grid is the mobile peer to the entries already listed (Jan, llama.cpp, LocalAI, ollama). Open-source iOS/Android app that runs LLMs entirely on-device:

- 100% offline, no account, no telemetry
- Built on llama.cpp + GGUF
- Runs Llama, Qwen, Gemma, Phi, DeepSeek, Mistral
- Voice mode (Whisper), vision, on-device image generation (Stable Diffusion), tool calling
- 1,785 stars on GitHub, MIT-licensed
- 10K+ Android installs

Inserted alphabetically between `ollama` and `PasteGuard`.