### PR TITLE
Add FastDDL to File Management and Sharing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ on the DMCrypt kernel module.
 - [Croc](https://github.com/schollz/croc) - Easily and securely send things from one computer to another.
 - [Dat-cp](https://github.com/tom-james-watson/dat-cp) - Copy files between hosts on a network using the peer-to-peer Dat network.
 - [Destiny](https://leastauthority.com/community-matters/destiny/) - Send files directly to the receiver in real-time. Developed for and with HROs as a free Privacy Enhancing Technology alternative.
+- [FastDDL](https://fastddl.com) - Temporary encrypted file sharing (AES-256-GCM). Files auto-delete after 24 hours. No registration. Publicly logs and displays visitor connection fingerprints for transparency.
 - [Gokapi](https://github.com/Forceu/Gokapi) - Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported.
 - [Lufi](https://framagit.org/fiat-tux/hat-softwares/lufi) - Let's Upload that FIle — File sharing software.
 - [Localsend](https://localsend.org/) - Share files to nearby devices. Free, open source, cross-platform.


### PR DESCRIPTION
## What's being added

[FastDDL](https://fastddl.com) — a temporary encrypted file sharing service.

## Why it belongs here

- Files are encrypted with **AES-256-GCM** before storage
- Files **auto-delete after 24 hours** — no manual cleanup needed
- **No registration** required to upload or download
- Transparent privacy model: publicly displays visitor connection fingerprints on download pages so users can see exactly what data is collected

## Entry added

In the **File Management and Sharing** → "Instead use" section, alphabetically between Destiny and Gokapi:

```
- [FastDDL](https://fastddl.com) - Temporary encrypted file sharing (AES-256-GCM). Files auto-delete after 24 hours. No registration. Publicly logs and displays visitor connection fingerprints for transparency.
```