### PR TITLE
Add qnote to Notes and Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Notally](https://github.com/OmGodse/Notally) - A beautiful notes app (local only, no sync).
 - [Notesnook](https://notesnook.com/) - Open source zero knowledge private note taking.
 - [Obsidian](https://obsidian.md) - Obsidian is the private and flexible note‑taking app. Closed source but has no trackers (website / apps) and E2EE sync. 
+- [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with local-only storage, no telemetry. Markdown live preview, real PDF export via Typst, OCR via Tesseract, automatic version history. Available on AUR.
 - [Quillpad](https://quillpad.github.io/) - Take beautiful markdown notes and stay organized with task lists. Fork of Quillnote.
 - [SiYuan](https://github.com/siyuan-note/siyuan) - A local-first personal knowledge management system.
 - [Standard Notes](https://standardnotes.org/) - A free, open-source, and completely encrypted notes app.


### PR DESCRIPTION
## What

Adds [qnote](https://github.com/Omibranch/qnote) to the **Notes and Tasks** section.

## Why it fits

qnote is a privacy-first note-taking app: all data stays local, no network requests, no telemetry, no accounts required. It stores notes and version history at `~/.local/share/qnote/` — nothing leaves the machine.

**Features:**
- Frameless minimal UI built with Tauri 2 (Rust + TypeScript)
- Markdown live preview
- Real PDF export via Typst (not HTML-in-disguise)
- OCR via Tesseract (local, offline)
- Automatic version history
- Dark/light themes, custom fonts

**Platform:** Linux. Available on AUR (`qnote`).

**License:** MIT