### PR TITLE
Add PDF Mavericks to Office — browser-only, no upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Fileverse](https://fileverse.io) - Fileverse is building healthier alternatives with self-sovereignty, privacy by design, and standards compliance at its core.
 	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 
  	- [dSheets](https://dsheets.new): decentralized alternative to Excel and Google Sheets.
+- [PDF Mavericks](https://www.pdfmavericks.com) - Browser-only PDF and JSON toolkit. 25+ tools, 100% client-side processing via WebAssembly. Files never leave your device — no upload, no account, no telemetry.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
PDF Mavericks (https://www.pdfmavericks.com) is a free, browser-based toolkit for PDF and JSON processing. 25+ tools including merge, split, compress, rotate, convert, sign, unlock, reorder pages, PDF-to-text, and JSON/Base64/JWT utilities.

Privacy angle: all processing runs client-side via WebAssembly. Files never touch a server — no upload path exists. No account, no analytics, no telemetry captured.

This makes it a direct privacy-respecting alternative to Adobe Acrobat Online, iLovePDF, and Smallpdf, all of which upload files to their servers for processing.

I am the maintainer. Open to format adjustments if needed.