### PR TITLE
Add dead-drop to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,7 @@ GNU/Linux is a family of free (as in freedom and as in free beer) and open sourc
 These tools are useful when sharing secrets, code snippets or any other kind of text with others in a private way.
 
 - [crypt.fyi](https://crypt.fyi) - Ephemeral zero-knowledge sensitive data sharing platform with web, cli, and chrome-extension clients
+- [dead-drop](https://github.com/davorinrusevljan/dead-drop) - Privacy-focused, ephemeral data sharing with zero-knowledge client-side AES-256-GCM encryption. Open source, self-destructing drops.
 - [NoPaste](https://github.com/bokub/nopaste) - Open Source pastebin alternative that works with no database, and no back-end code. Instead, the data is compressed and stored entirely in the link that you share, nowhere else.
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin) - A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.


### PR DESCRIPTION
## Addition

**Service name:** dead-drop
**Section:** Pastebin and Secret Sharing
**URL:** https://dead-drop.xyz
**Source code:** https://github.com/davorinrusevljan/dead-drop

**Description:** Privacy-focused, ephemeral data sharing with zero-knowledge client-side AES-256-GCM encryption.

**Why it fits:**
- ✅ Privacy-oriented — zero-knowledge architecture, server never sees plaintext
- ✅ Open source (MIT license)
- ✅ No user tracking, no accounts required
- ✅ Client-side encryption using AES-256-GCM with PBKDF2 key derivation (100k iterations)
- ✅ Ephemeral — drops auto-destruct after 7 days
- ✅ Free tier with no API key needed
- ✅ Public API with OpenAPI spec for programmatic access

Similar to existing listings (crypt.fyi, Yopass, scrt.link, dele-to) but with a focus on being a developer-friendly API-first service with version history support.