### PR TITLE
Add Mundwerk to Speech to Text > Apps and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [Mundwerk](https://mundwerkapp.de) - Local push-to-talk dictation app for macOS, runs whisper.cpp on-device. No cloud, no telemetry, no account; audio never leaves the device.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
Adds [Mundwerk](https://mundwerkapp.de) to `#### Speech to Text > Apps and services`, alphabetical (before OpenWhispr).

**Privacy-listing rationale (per misc/Contributing.md requirements):**
- **Clear privacy-oriented policy:** 100 % local processing on Apple Silicon. Audio never leaves the device. No cloud, no analytics, no telemetry, no account. Privacy policy: https://mundwerkapp.de/datenschutz.html / https://mundwerkapp.de/en/privacy.html
- **No user-tracking on project website:** mundwerkapp.de uses no analytics scripts (no GA, Plausible, Umami, Fathom, Matomo). Verified by HTML inspection.
- **Open source:** the app itself is closed-source (paid product, MoR Lemon Squeezy). I'm aware the contributing guide notes "some service without Open Source code may be added if there is special trust from community and has a good history privacy-wise" — Mundwerk is brand-new (released 2026-05-04), so I understand if this is a blocker. Submitting nonetheless because the architecture is verifiably offline-only (no network code in the audio pipeline; whisper.cpp + Silero VAD + AVAudioEngine, all local). Notarized by Apple, hardened runtime.

Description:
`Local push-to-talk dictation app for macOS, runs whisper.cpp on-device. No cloud, no telemetry, no account; audio never leaves the device.`