### PR TITLE
Add StarWhisper to Speech to Text apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.
+	- [StarWhisper](https://starwhisper.ai) - Windows desktop app for offline voice dictation. Runs Whisper locally via whisper.cpp, types into any application, free tier of 500 words per day.
 
 #### Image Generation
 


### PR DESCRIPTION
Adds StarWhisper to the "Speech to Text → Apps and services" subsection.

StarWhisper is a Windows desktop voice dictation app that runs OpenAI Whisper fully offline on the user's machine via whisper.cpp. No audio leaves the device by default. Privacy-relevant because it's the only Windows-native polished alternative to Wispr Flow / Dragon / Otter that doesn't require sending audio to a cloud service.

- https://starwhisper.ai
- Hotkey-driven, types into any application
- Free tier 500 words/day
- Optional opt-in cloud fallback with explicit per-clip consent