### PR TITLE
Add OpenQuack to Speech to Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [OpenQuack](https://github.com/larryxiao/openquack) - On-device voice dictation for macOS — transcribes a 5-minute clip in 2.8 s; paste at cursor, no telemetry, no account, no network call. 99 Whisper languages. MIT-licensed open source alternative to Wispr Flow.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
Adds [OpenQuack](https://github.com/larryxiao/openquack) under **Artificial Intelligence → Speech to Text → Apps and services**.

Privacy checklist:
- ✅ No user tracking — no telemetry, no analytics, no account required
- ✅ No network calls during transcription — all processing is on-device via WhisperKit / Core ML
- ✅ Open source MIT — full source on GitHub
- ✅ Clear privacy posture — architecture makes server-side capture structurally impossible (no server)

macOS menu-bar dictation app: press hotkey, speak, release — transcript pastes at cursor. 99 Whisper languages, ~8 MB native Swift, no telemetry. MIT-licensed open source alternative to Wispr Flow.

Inserted alphabetically before OpenWhispr (Q < W).