### PR TITLE
Add Dakera to self-hosted AI — privacy-preserving local agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 
+#### Agent Memory
+
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with no external data sharing. All memories are stored locally using RocksDB and HNSW vector indexing. MCP-native protocol means your AI agents' context never leaves your infrastructure.
+
 #### AI Coding
 
 - [Continue](https://github.com/continuedev/continue) - Open-source autopilot for VS Code and JetBrains—the easiest way to code with any LLM


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Artificial Intelligence > Agent Memory** section (new sub-section).

## Why it fits

Dakera is a self-hosted agent memory server that keeps all data on your own infrastructure — no external APIs, no cloud dependencies, no data sharing. It stores AI agent memories locally using RocksDB and HNSW vector indexing, and exposes them over the MCP protocol. This directly addresses the privacy concern described in the AI section intro: *"data you input is often collected and stored by the service provider."*

Key privacy properties:
- All memories stored locally — no data ever leaves your server
- No external API calls for storage or retrieval
- Open source, self-hostable via Docker or binary
- MCP protocol means your AI agent context stays in your own infrastructure

## Entry added

Under a new `#### Agent Memory` sub-section within `## Artificial Intelligence`:

```
- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with no external data sharing. All memories are stored locally using RocksDB and HNSW vector indexing. MCP-native protocol means your AI agents' context never leaves your infrastructure.
```