### PR TITLE
Add firefox-stealth (Firefox hardening patches) under Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1599,6 +1599,7 @@ Here are some open source and truly private (no personal data and/or credit card
 - [Brave](https://brave.com/) - Brave offers a pretty good out-of-the-box set of privacy and tracker protections.
 - [Firefox](https://www.mozilla.org/en-US/firefox/new/) - Open Source, independent browser. It needs some [hardening and tweaking](https://anonymousplanet.org/guide.html#firefox-1) to achieve great privacy.
   - [LibreWolf](https://librewolf.net/) - Privacy-focused Firefox fork.
+  - [firefox-stealth](https://github.com/feder-cr/firefox-stealth) - C++ source patches that harden Firefox against browser fingerprinting (Canvas, WebGL, AudioContext, Fonts, WebRTC, Timezone, DevTools detection). MPL-2.0.
 - [Tor Browser](https://www.torproject.org/)
 - [Mullvad Browser](https://mullvad.net/en/browser/) - Browser with the privacy and security implications of the Tor Browser, without the use of the Tor network.
 


### PR DESCRIPTION
C++ source patches against mozilla-central that harden Firefox against browser fingerprinting at the source level (Canvas 2D, GPU/WebGL, AudioContext, Fonts, WebRTC, Timezone, DevTools detection, 15 patches total). MPL-2.0, matching upstream Mozilla.

Different angle from LibreWolf or Mullvad Browser: distributed as source patches you apply yourself with `git am`, or as a pre-built binary on the release page if you don't want to compile from source.

No telemetry, no tracking on the project page. Self-disclosure: I am the author.

Repo: https://github.com/feder-cr/firefox-stealth