### PR TITLE
Add nosend.io to Images section

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [Fawkes](https://github.com/Shawn-Shan/fawkes) - privacy preserving tool against facial recognition systems.
   - [CloakMe](https://github.com/pluja/CloakMe) - Web interface for Fawkes algorithm.
 - [ImageScrubber](https://github.com/everestpipkin/image-scrubber) - A friendly browser-based tool for anonymizing photographs taken at protests ([hosted version provided by everestpipkin](https://everestpipkin.github.io/image-scrubber/)).
+- [nosend.io](https://nosend.io) - Browser-based image compressor. Supports JPG, PNG, WEBP, GIF, and HEIC. Files are processed entirely client-side and never leave your device. No account, no upload, no size limits. Open source (MIT).
 
 ### Text
 - [Stegcloak](https://stegcloak.surge.sh/) - Hide secrets with invisible characters in plain text securely using passwords ([repo](https://github.com/kurolabs/stegcloak)).


### PR DESCRIPTION
Adding nosend.io under the existing Images section.

**[nosend.io](https://nosend.io)** — Browser-based image compressor. Supports JPG, PNG, WEBP, GIF, and HEIC. Files are processed entirely client-side using the Canvas API and never leave the device. No account, no upload, no size limits.

## Why it fits

Most image compression tools send your files to a server. nosend.io does not. It aligns with the core principle of this list: privacy-respecting alternatives that don't require trusting a third party with your data.

- No cookies, no tracking
- No account required
- No data sent to external servers
- Open source (MIT): https://github.com/chivesz/nosend