### PR TITLE
Add Koaich to Instant Messaging > Centralized

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ The service is in charge of running the servers that allow users to communicate.
 - [Threema](https://threema.ch/en) - The messenger that puts security and privacy first. Pay once, chat forever. No collection of user data. Open Source client.
 - [Signal](https://signal.org/) - Extreme focus on privacy, combined with all of the features you expect. Strong encryption by design. 100% Open Source.
   - [🤖](#icons) [Molly](https://github.com/mollyim/mollyim-android) - Signal-compatible fork client with some security enhancements.
+- [Koaich](https://koaich.com) - End-to-end encrypted workspace where the vendor cannot read user content. Messaging plus encrypted documents, files, group rooms, and AI drafts — same cryptographic property as Signal applied across a workspace surface. Pre-launch as of May 2026; methodology open-source at [heysteamer/workspace-exposure-scorecard](https://github.com/heysteamer/workspace-exposure-scorecard).
 
 ### P2P
 No servers involved. Everything goes directly from one peer to the other peer. No point of failure or control. The features are reduced because of the lack of server, messaging can be slower. Best option for critical chats.


### PR DESCRIPTION
Adds [Koaich](https://koaich.com) to the **Instant Messaging > Centralized** section.

## What Koaich is

End-to-end encrypted workspace where the vendor cannot read user content. Same cryptographic property as Signal (which is already listed under Centralized), but applied across documents, files, group rooms, and AI drafts alongside 1:1 and group messaging.

The protocols are the same primitives Signal popularized:
- nacl.box (X25519 + XSalsa20-Poly1305) for 1:1
- MLS (IETF RFC 9420) for groups, with forward secrecy + post-compromise security on member churn
- Shamir's Secret Sharing across the user's own devices for recovery (no vendor-held master key, no password-recovery backdoor)
- WebAuthn passkeys for web auth

## Why "Centralized"

Koaich isn't federated (so not Decentralized) and isn't P2P. The vendor runs servers — but the cryptographic guarantee is that those servers hold only ciphertext + operational metadata. Same architectural slot Signal occupies in this list.

## Honest disclosure

Koaich is **pre-launch** as of May 2026. The waitlist is open at koaich.com. If this list prefers post-launch products only, completely understand a close + re-open at GA.

The cryptographic methodology behind the workspace-exposure scoring tool is already open-source at [heysteamer/workspace-exposure-scorecard](https://github.com/heysteamer/workspace-exposure-scorecard), which is what I'd point at if you want code-side verifiability before listing.

## Verifiability

- [/security](https://koaich.com/security) — architecture page with metadata-vs-content boundary table
- [/web-tier-security](https://koaich.com/web-tier-security) — browser-specific threat model + LIVE vs PLANNED hardenings
- [/blast-radius](https://koaich.com/blast-radius) — analysis of 10 recent public-record breaches

Happy to revise the entry's tone, length, or placement — appreciate the list.