### PR TITLE
Add Good Friction for LinkedIn to Browser Addons > Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1619,6 +1619,7 @@ Please read about what the addon does before installing. If you don't understand
 
 #### Useful Tools
 - [Single File](https://github.com/gildas-lormeau/SingleFile) - Save a faithful copy of an entire web page in a single HTML file so you can use it offline.
+- [Good Friction for LinkedIn](https://github.com/tabrez-syed/goodfriction-linkedin-extension) - Returns the moment of choice to the LinkedIn feed — a session timer and pagination break ask if you want to keep going; a nudge, not a blocker. Open source, no tracking.
 
 ### Browser Sync
 - [xBrowserSync](https://www.xbrowsersync.org/) - Browser syncing as it should be: secure, anonymous and free!


### PR DESCRIPTION
Good Friction for LinkedIn is an open-source Chrome extension that adds a session timer and an end-of-feed pause to LinkedIn — a nudge rather than a blocker.

Architecture-wise it fits this list: no servers, no accounts, no tracking, no data collection. Settings persist locally via `chrome.storage`. MIT licensed.

I placed it under Browser Addons > Useful Tools since there's no Distraction Management section. Happy to move it if there's a better fit. I built this one.

Thanks for maintaining the list — Mirlo's PR #759 (also mine, language learning) is in the same section if it merges first.