### PR TITLE
Add ATS Resume Checker to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,6 +1482,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 [Back to top 🔝](#contents)
 
 ## Utilities
+- [ATS Resume Checker](https://hugounoclaw.github.io/ats-checker/) - Check how Applicant Tracking Systems parse your resume, entirely in your browser. Your PDF is parsed locally via pdf.js and never uploaded; no accounts, no analytics, no cookies. Open source (MIT).
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
 


### PR DESCRIPTION
### What

Adds **ATS Resume Checker** to the **Utilities** section — a client-side tool that shows how an Applicant Tracking System parses a resume (0–100 score, keyword match, prioritized fixes).

### Why it belongs on a privacy list

Mainstream ATS/resume scanners (Jobscan, Resume Worded, etc.) require you to **upload your full CV** — name, contact details, address, and complete employment history, some of the most sensitive PII a person hands over — to their servers. This tool is a privacy-respecting alternative:

- **Nothing is uploaded.** The PDF is parsed in-browser via `pdf.js` (`file.arrayBuffer()` → `pdfjsLib.getDocument({data})`). No `fetch`/`XHR` of your document anywhere.
- **No accounts, no analytics, no cookies, no localStorage.**
- **Open source, MIT** — source: https://github.com/hugounoclaw/ats-checker
- Static site, trivially self-hostable (just static files).

### Honest disclosures

- **One external request on page load:** `pdf.js` is loaded from `cdnjs.cloudflare.com` rather than bundled, so the browser fetches that script from Cloudflare's CDN. No user document is involved — but it is one third-party request, so I'm flagging it rather than claiming "zero external requests."
- **Commercial element:** the page links to an optional paid resume kit. The checker itself is free and fully functional with no paywall.
- **Self-submission:** I'm the author. Flagging per good etiquette; happy to adjust wording, section, or drop it if it's not a fit.

### Entry

```
- [ATS Resume Checker](https://hugounoclaw.github.io/ats-checker/) - Check how Applicant Tracking Systems parse your resume, entirely in your browser. Your PDF is parsed locally via pdf.js and never uploaded; no accounts, no analytics, no cookies. Open source (MIT).
```
