### PR TITLE
Add Agora Cosmica to AI > ChatGPT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ When using cloud-based AI services, the data you input is often collected and st
 
 #### ChatGPT
 
+- [Agora Cosmica](https://github.com/chipmates/agoracosmica) - No-tracking educational platform with 30 historical figures from philosophy, science, art, mysticism, and activism. Self-hostable via Docker, bring-your-own-key OpenRouter LLM, AGPL-3.0, German nonprofit.
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ When using cloud-based AI services, the data you input is often collected and st
 
 #### ChatGPT
 
-- [Agora Cosmica](https://github.com/chipmates/agoracosmica) - No-tracking educational platform with 30 historical figures from philosophy, science, art, mysticism, and activism. Self-hostable via Docker, bring-your-own-key OpenRouter LLM, AGPL-3.0, German nonprofit.
+- [Agora Cosmica](https://github.com/chipmates/agoracosmica) - Open-source (AGPL-3.0) platform to learn from 30 historical figures through AI "Echoes". No tracking cookies, no profiling, no IP retention in analytics; self-hostable via Docker with an on-device Local Mode. German nonprofit.
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.


### PR DESCRIPTION
**Agora Cosmica** is an open-source (AGPL-3.0) educational platform from a German nonprofit. You learn from 30 historical figures and can talk with an AI "Echo" of each. It self-hosts with one Docker command, and a Local Mode runs the language model and all speech on the user's own machine, so in that mode no conversation data leaves the device.

On your "no user-tracking on the project website" requirement, here is the full picture, including the one exception, so you can judge it directly:

**No tracking by default.** No tracking cookies, no third-party analytics, no profiling, no IP retention. The only measurement is keyless, aggregate counts with no join key between events (the same model Plausible and Umami use). Details: [docs/MEASUREMENT.md](https://github.com/chipmates/agoracosmica/blob/main/docs/MEASUREMENT.md).

**The one exception, and it is opt-in.** Visitors who arrive through our free nonprofit Google Ad Grants ads carry a Google click ID (`gclid`) in the URL. It is forwarded to Google Ads **only if the visitor actively opts in** through a non-blocking prompt that is **off by default** (stored as `agc_ad_consent` in localStorage, revocable any time in Settings). Nothing is sent without that opt-in. Visitors from paid ads are dropped on arrival and never captured at all. When opted in, what reaches Google is the `gclid`, a conversion label, a timestamp, value, currency, and an order id, and nothing else: no figure, no message content, no profile, no client id. On the browser the `gclid` lives in tab-scoped sessionStorage and is never written into our own analytics.

You can verify all of this in code, not just take our word:
- consent prompt (default off): [`marketing/src/islands/AdConsentPrompt.tsx`](https://github.com/chipmates/agoracosmica/blob/main/marketing/src/islands/AdConsentPrompt.tsx)
- capture logic: [`client/src/utils/public/gclidCapture.ts`](https://github.com/chipmates/agoracosmica/blob/main/client/src/utils/public/gclidCapture.ts)
- the only forward path: [`workers/llm-proxy/src/routes/conversions.ts`](https://github.com/chipmates/agoracosmica/blob/main/workers/llm-proxy/src/routes/conversions.ts)

Happy to adjust the entry, move it to a more fitting section, or soften any wording you prefer.
