### PR TITLE
Add TabFlow + Invoco: privacy-first, local-only, open-source tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [LinkAce](https://github.com/Kovah/LinkAce)
 - [LinkDing](https://github.com/sissbruecker/linkding)
 - [Shiori](https://github.com/go-shiori/shiori)
+- [TabFlow](https://selfloom.github.io/tabflow/) - AI-organized bookmark dashboard that replaces your new tab page. All data stored locally on your device — no tracking, no account required.
 - [Wallabag](https://wallabag.org/) - Open-source, optionally self-hosted, read it later server. Provides paid hosted service with privacy in mind.
 
 ### Book and web annotations/highlights management
@@ -1129,6 +1130,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ### Others 
 
 - [Debitum](https://github.com/Marmo/debitum) - With Debitum you can track all kinds of IOUs, be it money or lent items.
+- [Invoco](https://selfloom.github.io/invoco-demo/) - Free offline-first invoice generator and time tracker for freelancers. No signup, no cloud storage — all data stays on your device.
 
 ### Portfolio trackers
 


### PR DESCRIPTION
## Changes

This PR adds two privacy-respecting tools:

### TabFlow (Bookmarking)
- AI-organized bookmark dashboard replacing new tab page
- All data stored locally (localStorage) -- no cloud sync, no tracking, no account
- Free, open source, single HTML file
- https://selfloom.github.io/tabflow/

### Invoco (Personal Finances > Others)
- Invoice generator + time tracker for freelancers
- All data stays in browser -- no signup, no cloud storage
- Free, open source, single HTML file
- https://selfloom.github.io/invoco-demo/

Both meet awesome-privacy criteria: free, open source, no data collection, local-only, no account required.