### PR TITLE
Add AI Security Gateway to Artificial Intelligence > ChatGPT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
+- [AI Security Gateway](https://github.com/aisecuritygateway/aisecuritygateway) - Open-source AI firewall and LLM proxy that auto-redacts 28+ PII types (SSN, credit cards, emails, etc.) from prompts before they reach any provider. Blocks prompt injection, enforces budgets, and routes across 600+ models. OpenAI SDK compatible, self-hosted, Apache 2.0.
 
 #### AI Coding
 


### PR DESCRIPTION
**What is it?**

AI Security Gateway is an open-source, self-hosted AI firewall that sits
between your application and any LLM provider. It auto-redacts 28+ PII
entity types (SSN, credit cards, emails, phone numbers, etc.) from every
prompt before it reaches the model — ensuring no sensitive data leaves
your infrastructure.

**Why it belongs in this list:**

- Privacy-first architecture: fully stateless, zero data residency
- Self-hosted under Apache 2.0
- OpenAI SDK compatible (2-line integration, no code changes)
- Similar to PasteGuard (already listed) but with broader PII coverage,
  prompt injection blocking, vision/OCR scanning, and multi-provider routing

**Links:**
- GitHub: https://github.com/aisecuritygateway/aisecuritygateway
- Website: https://aisecuritygateway.ai
- License: Apache 2.0