### PR TITLE
Adds MetadataRemove to Photo Editing and Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [MetadataRemove](https://metadataremove.app) - Browser-based metadata removal for photos, PDFs, Office documents, video, and audio. Files processed locally — no uploads. Also has a [file metadata privacy checklist](https://metadataremove.app/file-metadata-privacy-checklist). Not open source.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
## Description

Added [MetadataRemove](https://metadataremove.app) to the **Photo Editing and Management → Web** section.

MetadataRemove is a browser-based tool that strips hidden metadata from:
- Photos (JPG, PNG, HEIC, WebP)
- PDFs
- Office documents (DOCX, XLSX, PPTX)
- Video (MP4, MOV, WebM)
- Audio (MP3)

All processing happens locally in the browser — no files are uploaded. Also includes a [file metadata privacy checklist](https://metadataremove.app/file-metadata-privacy-checklist).

**Note:** This tool is not open source. It is listed as source-available with clear privacy documentation. I am adding it because it meets the privacy-first criteria (local processing, no uploads, no tracking) and fills a gap for multi-format browser-based metadata removal.

**Disclosure:** I am the developer of MetadataRemove.