### PR TITLE
Add NoChat to Instant Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ The service is in charge of running the servers that allow users to communicate.
 - [Threema](https://threema.ch/en) - The messenger that puts security and privacy first. Pay once, chat forever. No collection of user data. Open Source client.
 - [Signal](https://signal.org/) - Extreme focus on privacy, combined with all of the features you expect. Strong encryption by design. 100% Open Source.
   - [🤖](#icons) [Molly](https://github.com/mollyim/mollyim-android) - Signal-compatible fork client with some security enhancements.
+- [NoChat](https://nochat.io/) - End-to-end encrypted messenger that requires no phone number; sign up anonymously or with email. Post-quantum encrypted 1:1 DMs (X25519 + ML-KEM-1024) and E2EE calls. Open source and free. Not yet independently audited.
 
 ### P2P
 No servers involved. Everything goes directly from one peer to the other peer. No point of failure or control. The features are reduced because of the lack of server, messaging can be slower. Best option for critical chats.


### PR DESCRIPTION
## What

Adds **[NoChat](https://nochat.io/)** to **Instant Messaging → Centralized**, alongside Signal and Threema.

NoChat is an open-source, end-to-end encrypted messenger that requires no phone number — you can sign up anonymously or with an email. It runs a centralized zero-knowledge server (the server only stores opaque encrypted blobs), with hybrid post-quantum encrypted 1:1 DMs (X25519 + ML-KEM-1024) and E2EE calls. Free, MIT-licensed, and cross-platform (web, iOS, Android, desktop).

I placed it under **Centralized** because messaging is routed through a server (not federated, not pure P2P).

## Entry added

```
- [NoChat](https://nochat.io/) - End-to-end encrypted messenger that requires no phone number; sign up anonymously or with email. Post-quantum encrypted 1:1 DMs (X25519 + ML-KEM-1024) and E2EE calls. Open source and free. Not yet independently audited.
```

## Notes for transparency

- **Not yet independently audited** — this is stated explicitly in the entry so as not to overstate, in line with the "open and audited" guidance in the Centralized section.
- **Affiliation:** I'm associated with the NoChat project, disclosing this per good practice.
- Website: https://nochat.io/ — Source: https://github.com/kindlyrobotics/nochat

Single addition, formatted per `misc/Contributing.md` (`- [Name](link) - description`), added at the bottom of the relevant subsection.