### PR TITLE
Add FunASR to Speech to Text models

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ When using cloud-based AI services, the data you input is often collected and st
 		- [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model.
 		- [faster-whisper](https://github.com/SYSTRAN/faster-whisper) - Reimplementation of Whisper using CTranslate2 that transcribes locally up to four times faster. MIT licensed.
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
+	- [FunASR](https://github.com/modelscope/FunASR) - Self-hostable speech recognition toolkit with MIT-licensed code for local ASR, VAD, punctuation, and speaker pipelines; model licenses vary.
 
 - **Apps and services**
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.


### PR DESCRIPTION
## Summary

Adds FunASR to **AI > Speech to Text > Models**.

FunASR is a self-hostable speech recognition toolkit for local ASR, VAD, punctuation, and speaker pipelines. The toolkit source is MIT-licensed; pretrained model licenses vary by model card. The entry links directly to the maintained GitHub source and does not require a hosted speech API.

## Checklist

- [x] Entry uses the repository house format and a one-sentence description
- [x] Source repository link is provided
- [x] Self-hosted/local privacy fit is explicit
- [x] Toolkit license and separate model-license boundary are stated
- [x] Repository is active and not archived
- [x] New section and separate project website checks are not applicable

## Validation

- exact head: `62dbdbf612b97dc55238881b3b50e2eda9234bbc`; 0 commits behind upstream main
- final diff: `README.md` only, +1/-0; `git diff --check` passes
- repository format lint: 1 added entry checked, 0 warnings
- repository openness check: 1 added repository checked, no concerns
- https://github.com/modelscope/FunASR returns HTTP 200; GitHub reports MIT, active, and not archived
- exact workflow-pinned lychee v0.23.0 comparison: upstream main has 843 links / 722 OK / 25 existing errors / 5 existing timeouts; this head has 844 / 723 / the same 25 / the same 5, so the added FunASR URL contributes one OK and no failure
- PR Lint run 29548786899 is `action_required` with 0 jobs pending maintainer approval for the fork workflow