### PR TITLE
Add Saju Fortune (privacy-respecting Korean astrology calculator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Google captchas use cookies to track users and rank their IPs.
 
 ## Creator Tools
 
+
+- [Saju Fortune (사주명리 풀이)](https://tarofortune.pythonanywhere.com) — Korean four-pillars astrology calculator. **No signup, no email, no tracking pixels** beyond standard GA. All computation done server-side without storing birth data. Useful as a privacy-respecting alternative to commercial astrology apps that profile users.
 Opt for open-source and P2P alternatives that prioritize data privacy, eliminate third-party interference, and offer transparent, community-backed functionalities over mainstream tools like Riverside.fm, Restream and Camtasia.
 
 - [vdo.ninja](https://vdo.ninja/) - Powerful tool that lets you bring remote video feeds into OBS or other studio software via WebRTC.


### PR DESCRIPTION
Adds **Saju Fortune** — a free Korean four-pillars astrology calculator that respects user privacy:

- URL: https://tarofortune.pythonanywhere.com
- **No signup or email** required to use the calculator
- **Birth data not stored** server-side (pure stateless computation)
- No tracking pixels beyond standard Google Analytics
- Alternative to commercial astrology apps that profile users and resell birth data

Solo-built, ad-supported. Happy to revise placement.
