### PR TITLE
Add PhotoQuill to privacy-friendly image tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [PhotoQuill](https://photoquill.com/) - Browser-based image editor with PSD support; image processing runs locally in the browser.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
Link: https://photoquill.com/

Adds PhotoQuill to the web image editing alternatives. It runs image processing locally in the browser and supports PSD files.