### PR TITLE
Add NoChat - private messaging without a phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ The service is in charge of running the servers that allow users to communicate.
 - [Threema](https://threema.ch/en) - The messenger that puts security and privacy first. Pay once, chat forever. No collection of user data. Open Source client.
 - [Signal](https://signal.org/) - Extreme focus on privacy, combined with all of the features you expect. Strong encryption by design. 100% Open Source.
   - [🤖](#icons) [Molly](https://github.com/mollyim/mollyim-android) - Signal-compatible fork client with some security enhancements.
+- [NoChat](https://nochat.io) - Private messaging and video calling without a phone number. E2EE (P-256 ECDH + AES-256-GCM), hybrid post-quantum DMs (X25519+ML-KEM-1024), open-source MIT, free forever, no ads. Not yet third-party audited.
 
 ### P2P
 No servers involved. Everything goes directly from one peer to the other peer. No point of failure or control. The features are reduced because of the lack of server, messaging can be slower. Best option for critical chats.


### PR DESCRIPTION
## What is NoChat?

[NoChat](https://nochat.io) is a free, open-source (MIT) private messaging and video-calling platform that does not require a phone number to sign up.

## Why it belongs here

NoChat meets the contributing requirements:

- **Privacy-oriented**: No phone number, no email required. No ads, no tracking.
- **Open source**: Client code is MIT-licensed at https://github.com/kindlyrobotics/nochat
- **E2EE**: Messages encrypted client-side with P-256 ECDH + AES-256-GCM before transmission. The server never sees plaintext.
- **Post-quantum DMs**: Direct messages use a hybrid X25519 + ML-KEM-1024 key-encapsulation envelope (deployed).
- **Free forever**: No subscription, no freemium limits.

## Honest caveats (included in the listing)

- Not yet independently third-party audited.
- Double Ratchet and Sealed Sender are planned but not yet shipped fleet-wide.

## Change

Added one line to the **Centralized** subsection of **Instant Messaging**, following the Signal entry — consistent with existing format.

```
- [NoChat](https://nochat.io) - Private messaging and video calling without a phone number. E2EE (P-256 ECDH + AES-256-GCM), hybrid post-quantum DMs (X25519+ML-KEM-1024), open-source MIT, free forever, no ads. Not yet third-party audited.
```

App Store: https://apps.apple.com/app/id6756893559