### PR TITLE
Add SansMail to disposable email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,9 @@ With email aliases, you can finally create a different identity for each website
 - [SimpleLogin](https://github.com/simple-login/app)
 - [AnonAddy](https://github.com/anonaddy/anonaddy)
 
+### Temporary / Disposable Email
+- [SansMail](https://sansmail.my.id) - Instant disposable email with realtime inbox via WebSocket, custom domain support, and auto-expire. No signup required.
+
 [Back to top 🔝](#contents)
 
 ## Maps and Navigation


### PR DESCRIPTION
## What is SansMail?

SansMail is a disposable email service that lets you generate temporary 
email addresses instantly without creating an account.

## Why it belongs here

- **Privacy-oriented:** No account required, no personal data stored, 
  emails auto-expire after 30 days
- **Realtime inbox:** Messages delivered instantly via WebSocket, 
  no polling or refresh needed
- **Custom domain support:** Point your own domain and it works immediately

## Honest caveats

- Hosted service, not self-hosted
- Requires a license key (Rp 15.000/month)

## Change

Added a new `Temporary / Disposable Email` subsection under Mail Services.

```markdown
- [SansMail](https://sansmail.my.id) - Disposable email with realtime 
  inbox, custom domain support, and auto-expire. No signup required.
```