### PR TITLE
Add Vaultool to Developer Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Opt for open-source and P2P alternatives that prioritize data privacy, eliminate
 
 ## Developer Tools
 - [Beekeeper Studio](https://www.beekeeperstudio.io) - Open Source SQL Editor and Database Manager with a privacy commitment in their mission statement.
+- [Vaultool](https://vaultool.com) - 31+ free online developer tools that run entirely in your browser. No signup, no data uploaded — your data never leaves your device. Includes JSON formatter, Base64 converter, image compressor, word counter, and more.
 
 ### IDEs
 ⛔ Avoid using privative IDEs that are full of trackers and telemetry.


### PR DESCRIPTION
## What
Adding [Vaultool](https://vaultool.com) to the Developer Tools section.

## Why
Vaultool provides 31+ free online developer tools that run 100%% in the browser with zero data sent to servers. No signup required. This aligns with this list's focus on privacy-respecting services.

Key features:
- All processing happens client-side — data never leaves the device
- No account/signup required
- No cookies, no tracking, no analytics
- Covers JSON formatting, Base64 encoding/decoding, image compression, word counting, and more

Homepage: https://vaultool.com