### PR TITLE
Add Meeting Transcriber to Speech to Text apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [Meeting Transcriber](https://github.com/pasrom/meeting-transcriber) - On-device macOS app that auto-records Teams/Zoom/Webex meetings, then transcribes, separates speakers, and writes a summary. No cloud, no telemetry. Open-source alternative to Otter and Fireflies.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
Adds **Meeting Transcriber** under `Artificial Intelligence → Speech to Text → Apps and services`, next to OpenWhispr (its closest peer).

It's an on-device macOS app that auto-records Teams/Zoom/Webex meetings, then transcribes, separates speakers, and writes a Markdown summary. Everything stays on the Mac — no cloud, no telemetry, no account. A privacy-respecting alternative to Otter/Fireflies.

Meets the listing requirements:
- Own-your-data: fully on-device, nothing leaves the machine.
- No user-tracking (it's a GitHub-hosted open-source project, no tracking site).
- Open source (MIT).

Disclosure: I'm the developer.