### PR TITLE
Add SwapFile.io to Photo Editing > Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [SwapFile.io](https://swapfile.io) - Privacy-first online image and PDF converter — files auto-deleted within 1 hour, no Google Analytics, no Facebook Pixel.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
This adds [SwapFile.io](https://swapfile.io) — an online image and PDF converter built around privacy guarantees.

### Why this fits the list

The list currently has no dedicated entry for online image/PDF conversion (a distinct use case from in-browser editing). Most popular alternatives in this space (Smallpdf, iLovePDF, CloudConvert) embed Google Analytics, Facebook Pixel, Hotjar, and aggressive retargeting — they're the "WeTransfer" of image conversion.

### Privacy commitments

- HTTPS upload, server-side processing using ImageMagick + Ghostscript
- **Anonymous files auto-deleted within 1 hour** (verifiable: https://swapfile.io/en/privacy-policy)
- **Plausible analytics only** — cookieless, 1 KB script, no fingerprinting
- **No Google Analytics, no Facebook Pixel, no Hotjar**
- No required signup for files under 5 MB (registered users: 15 MB)

### Transparency notes (please review)

- **Closed-source** for now (single-founder project, no current self-host option). Considering open-source after Q4 2026 monetization. I understand if this is a dealbreaker — happy to revisit when the source is published.
- **Server-side processing** (files leave the user's browser). This differs from in-browser tools like miniPaint. We compensate with the auto-delete guarantee and analytics minimization.

### Supported conversions

96 source × target combinations: HEIC, AVIF, WebP, JPG, PNG, GIF, BMP, TIFF, plus PDF → image and PDF merge (multi-PDF combination).

Happy to address any feedback. Thanks for maintaining this list.