### PR TITLE
Add decode64.com — privacy-respecting browser-based developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Opt for open-source and P2P alternatives that prioritize data privacy, eliminate
 [Back to top 🔝](#contents)
 
 ## Developer Tools
+- [decode64.com](https://decode64.com) - Suite of browser-based developer tools (Base64 decoder, JSON formatter, URL encoder, color picker). No server, no uploads — all processing is client-side.
 - [Beekeeper Studio](https://www.beekeeperstudio.io) - Open Source SQL Editor and Database Manager with a privacy commitment in their mission statement.
 
 ### IDEs


### PR DESCRIPTION
Adding [decode64.com](https://decode64.com) — a suite of free developer tools that process everything client-side.

**Why it fits the privacy focus:**
- Zero server uploads — all processing happens in the browser
- No analytics, no tracking, no cookies
- Safe for sensitive data: API keys, JWT tokens, internal configs

**Tools included:**
- Base64 Decoder/Encoder — https://decode64.com
- JSON Formatter — https://decode64.com/json-formatter  
- URL Encoder/Decoder — https://decode64.com/url-encoder
- Color Picker — https://decode64.com/color-picker
- HTML Formatter — https://decode64.com/html-formatter

Source: https://github.com/zenopanda705-png/base64-decoder (MIT)