### PR TITLE
Add ScorchPad - zero-knowledge encrypted pastebin

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ on the DMCrypt kernel module.
 - [Snapdrop](https://github.com/RobinLinus/snapdrop) - A Progressive Web App for local file sharing inspired by Apple's Airdrop.
 - [Winden](https://winden.app/) - A convenient version of Magic Wormhole you can use from within your browser. No need to install an app.
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
+- [ScorchPad](https://github.com/scorchpad/scorchpad) - Zero-knowledge encrypted pastebin where the server only ever sees ciphertext. AES-256-GCM encryption in the browser, decryption key in the URL fragment, burn-after-reading, and a monthly warrant canary. 
 - [scrt.link](https://scrt.link/file) - End-to-end encrypted file transfer. Up to 100GB and 30 days retention. Stored in Switzerland.
 
 [Back to top 🔝](#contents)


### PR DESCRIPTION
Adding ScorchPad to the Pastebin and Secret Sharing section. Zero-knowledge architecture using AES-256-GCM browser-side encryption with the decryption key in the URL fragment, so the server only ever sees ciphertext. Includes burn-after-reading, password protection, and a monthly warrant canary. MIT licensed and open source.