### PR TITLE
Add PII Blackout to Document Editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 ✅  **Instead use**
 - [LibreOffice](https://www.libreoffice.org/) - Free and open source offline office.
 - [OnlyOffice](https://www.onlyoffice.com/) - Free and open source online office for collaboration.
+- [PII Blackout](https://piiblackout.com) - 100% offline, AI-powered desktop application to safely detect and permanently redact PII/PHI from PDF files and images with zero cloud uploads
 - [Cryptpad](https://cryptpad.fr/) - Collaboration suite, encrypted and open-source.
 - [Etherpad](https://etherpad.org/) - Highly customizable open source online editor providing collaborative editing in really real-time.
 - [Fileverse](https://fileverse.io) - Fileverse is building healthier alternatives with self-sovereignty, privacy by design, and standards compliance at its core.


### PR DESCRIPTION
Hi! I would like to add my local-first PII redaction tool to the Document Editors section. It helps users permanently and safely mask sensitive data inside PDFs locally without cloud leaks.

- **Project Link**: [PII Blackout](https://piiblackout.com)
- **Relationship**: I am the independent full-stack developer of this tool (Self-promotional disclosure).