### PR TITLE
Add PDF Toolbox — privacy-first browser-based PDF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [LibreOffice](https://www.libreoffice.org/) - Free and open source offline office.
 - [OnlyOffice](https://www.onlyoffice.com/) - Free and open source online office for collaboration.
 - [Cryptpad](https://cryptpad.fr/) - Collaboration suite, encrypted and open-source.
+- [PDF Toolbox](https://github.com/hwlsniper/pdftoolbox) - Free browser-based PDF tools (compress, merge, split, convert). All processing happens locally — files never leave your computer.
 - [Etherpad](https://etherpad.org/) - Highly customizable open source online editor providing collaborative editing in really real-time.
 - [Fileverse](https://fileverse.io) - Fileverse is building healthier alternatives with self-sovereignty, privacy by design, and standards compliance at its core.
 	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 


### PR DESCRIPTION
## Description

PDF Toolbox is a free, open-source suite of PDF tools that runs entirely in the browser using WebAssembly. Unlike every other online PDF tool (Smallpdf, iLovePDF, etc.), PDF Toolbox never uploads files to a server.

**Why it fits:** Complete privacy — all processing is local. No registration, no uploads, no limits.

**Website:** https://pdftoolbox-three.vercel.app
**Repo:** https://github.com/hwlsniper/pdftoolbox

**Tools:** Compress PDF, Merge PDF, Split PDF, PDF to JPG, JPG to PDF, PDF to Word, Unlock PDF, Protect PDF