### PR TITLE
Add Private Terminal to Portfolio trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 
 - [Ghostfolio](https://github.com/ghostfolio/ghostfolio#readme) - open source wealth management software built with web technology.
 - [PortfolioPerformance](https://www.portfolio-performance.info/en/) - An open source tool to calculate the overall performance of an investment portfolio-
+- [Private Terminal](https://github.com/cerkon1/private-terminal) - A free, open source (MIT), local-first desktop research dashboard for stocks, crypto and macroeconomics. No accounts, no telemetry, no cloud sync — all data stays in a local SQLite database.
 - [Rotki](https://github.com/rotki/rotki) - An awesome portfolio tracking, analytics, accounting and tax reporting application that protects your privacy.
 
 ## Photo Editing and Management


### PR DESCRIPTION
Adds [Private Terminal](https://github.com/cerkon1/private-terminal) under Personal Finances → Portfolio trackers.

A free, MIT-licensed, local-first desktop research dashboard (Tauri v2: Rust + React). Watchlist, multi-indicator charts, FRED macro dashboard, and cross-asset analysis tools. Privacy properties: no accounts, no telemetry, no analytics, no cloud sync — everything is stored in a local SQLite file, and the only network calls are to the public data sources the user enables (FRED, Yahoo Finance quotes, optional RSS feeds).

Disclosure: I'm the author.