### PR TITLE
Add Lockpaw (resubmission of #731)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [Lockpaw](https://github.com/sorkila/lockpaw) - Free, open source (MIT) macOS menu bar screen guard. Lock your screen with a hotkey without sleeping — AI agents and tasks keep running with input blocked, the screen glows when an agent needs you, and Touch ID unlocks.
 
 ### Android
 


### PR DESCRIPTION
Hi! This resubmits #731, which was auto-closed when I accidentally deleted the source fork during an account cleanup — it had not been reviewed or rejected. Sorry for the noise, and thanks for maintaining the list.

**Lockpaw** is a free, open source (MIT) macOS menu bar screen guard. It covers and locks your screen with a global hotkey without putting the Mac to sleep, so long-running sessions and AI coding agents keep working while keyboard/mouse input is blocked; the locked screen glows when an agent needs your attention, and you unlock with the hotkey or Touch ID. Native Swift, no analytics or telemetry of any kind.

- Website: https://getlockpaw.com
- Source: https://github.com/sorkila/lockpaw

Added under **Privacy Tools → Desktop** following the entry format from the Contributing guide.