### PR TITLE
Add LogZero under Mood and habit trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 	- [Food](#food)
 	- [Menstrual cycle trackers](#menstrual-cycle-trackers)
 	- [Medical health](#medical-health)
+	- [Mood and habit trackers](#mood-and-habit-trackers)
 - [Fonts](#fonts)
 - [Forms](#forms)
 - [Games](#games)
@@ -575,6 +576,9 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 
 ### Medical health
 - [Fasten](https://github.com/fastenhealth/fasten-onprem) - Fasten is an open-source, self-hosted, personal/family electronic medical record aggregator, designed to integrate with 1000's of insurances/hospitals/clinics.
+
+### Mood and habit trackers
+- [LogZero](https://logzero.app) - An all-in-one personal life and habit tracker for iOS (mood, medication, food, exercise, meditation, weight, to-dos) with a private alternative to Daylio and Bearable. Closed source, but stores everything on-device with no account, no ads and no telemetry. Encrypted at rest with optional user-controlled encrypted exports.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds **LogZero** under **Fitness and Health**, in a new `Mood and habit trackers` sub-section (with a matching table-of-contents entry).

LogZero is an all-in-one personal life & habit tracker for iOS (mood, medication, food, exercise, meditation, weight, to-dos) — a private alternative to Daylio and Bearable. Closed-source, but stores everything on-device with no account, no ads and no telemetry; encrypted at rest with optional user-controlled encrypted exports.

- Website: https://logzero.app
- App Store: https://apps.apple.com/app/id6773557137

Follows the documented `- [Name](url) - Description.` service format.
