### PR TITLE
Add csvtodashboard to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,6 +1482,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 [Back to top 🔝](#contents)
 
 ## Utilities
+- [csvtodashboard](https://csvtodashboard.com) - Free CSV/Excel toolkit (editor, SQL, converters, dashboards) that runs 100% client-side - files never leave the browser. Core parser is open source.
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
 


### PR DESCRIPTION
Adds csvtodashboard under **Utilities** (alphabetical, before Deskreen) — a free CSV/Excel toolkit (editor for million-row files, SQL queries, format converters, auto-built dashboards) where everything runs client-side and files never leave the browser.

Privacy notes, since that is the point of this list:
- No accounts, no signup, no upload — parsing runs in a Web Worker, SQL is DuckDB compiled to WASM, all in the tab. Verifiable in DevTools: no network request ever carries file data.
- The CSV parser core is open source: https://github.com/OSP-Engineer/csvtd-parser. The site itself is free and ad-supported (Google AdSense is the only third party).

Disclosure: I work on this tool. Happy to adjust the wording or drop the entry if it is not a fit for the list.