### PR TITLE
Add WhisperPress to Speech to Text > Apps and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.
+	- [WhisperPress](https://github.com/b84330808/whisperpress) - Push-to-talk voice typing and voice notes for Windows. Hold a hotkey to dictate into any app; transcription runs locally via whisper.cpp. Open source.
 
 #### Image Generation
 


### PR DESCRIPTION
Adds WhisperPress under **Speech to Text → Apps and services**, alongside OpenWhispr.

WhisperPress is a free, MIT-licensed dictation app for Windows: hold a hotkey, speak, release — the transcript is typed into whatever app your cursor is in. All transcription runs locally via whisper.cpp; audio never leaves the machine, which is why it fits this list. Also does meeting transcription via system-audio loopback and audio file imports.

Repo (with demo video): https://github.com/b84330808/whisperpress