### PR TITLE
Add ConvertiZen to Document Conversion section under Office

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,7 +946,9 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Fileverse](https://fileverse.io) - Fileverse is building healthier alternatives with self-sovereignty, privacy by design, and standards compliance at its core.
 	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 
  	- [dSheets](https://dsheets.new): decentralized alternative to Excel and Google Sheets.
+### Document Conversion
 
+- [ConvertiZen](https://convertizen.netlify.app) - Privacy-friendly document converter that works entirely in your browser. No file uploads, no server processing — convert PDF, Word, Excel and more using WebAssembly. Free to use.
 [Back to top 🔝](#contents)
 
 ## Online Phone Providers


### PR DESCRIPTION
## Add ConvertiZen to Office > Document Conversion

ConvertiZen (https://convertizen.netlify.app) is a privacy-friendly document converter that runs entirely in the browser using WebAssembly. There are no file uploads and no server processing — all conversions happen locally on the user's device.

**Why it fits awesome-privacy:**
- Zero data leaves the user's machine
- - No account required
- - Open to use, no tracking
- - Supports PDF, Word, Excel, images and more
- - Freemium model with no ads
Added under a new `### Document Conversion` subsection within `## Office`.