### PR TITLE
Add SwiftFloris to Android Keyboard section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Preinstalled file managers and third-party file manager apps found on the play s
 - [Indic Keyboard](https://gitlab.com/indicproject/indic-keyboard) - Indic Keyboard is a versatile keyboard for Android users who wish to use Indic and Indian languages to type messages, compose emails and generally prefer to use them in addition to English on their phone.
 - [OpenBoard](https://github.com/openboard-team/openboard) - OpenBoard is a 100% foss keyboard based on AOSP, with no dependency on Google binaries, that respects your privacy. It is no longer updated, but still works.
 - [Simple Keyboard](https://github.com/rkkr/simple-keyboard) - Simply keyboard and nothing more.
+- [SwiftFloris](https://github.com/SysAdminDoc/SwiftFloris) - A privacy-first Android keyboard forked from FlorisBoard. No internet permission, no telemetry, no account required. Features autocorrect, gesture typing, clipboard manager and multilingual support.
 
 ### Android Gallery
 


### PR DESCRIPTION
## Summary

Adds [SwiftFloris](https://github.com/SysAdminDoc/SwiftFloris) to the Android Keyboard section.

SwiftFloris is a privacy-first Android keyboard forked from FlorisBoard. Key privacy properties:

- **No INTERNET permission** in the manifest — the app cannot make network requests at all
- **No telemetry, no analytics, no account** required
- **Apache-2.0** licensed, fully open source

Features include autocorrect, gesture typing, clipboard manager, emoji support, and multilingual input. Targets Android 8.0+.

The entry is placed alphabetically among the existing keyboard alternatives.