### PR TITLE
Add Squirrel to Bookmarking — browser-local, no account, no favicon l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [LinkAce](https://github.com/Kovah/LinkAce)
 - [LinkDing](https://github.com/sissbruecker/linkding)
 - [Shiori](https://github.com/go-shiori/shiori)
+- [Squirrel](https://squirrel.aditco.in/) - Private bookmark manager that runs entirely in your browser. No account, no cloud, no server — not even favicon requests leave your device. Free for 25 bookmarks; $9 one-time for unlimited with vault folder sync.
 - [Wallabag](https://wallabag.org/) - Open-source, optionally self-hosted, read it later server. Provides paid hosted service with privacy in mind.
 
 ### Book and web annotations/highlights management


### PR DESCRIPTION
**What is Squirrel?**
Squirrel is a private bookmark manager that stores everything in the browser's 
IndexedDB — no account, no cloud, no server involved at any point.

**Why it belongs here:**
- No data ever leaves the browser during normal use
- Favicons fetched directly from each site's own domain — not via Google's favicon 
  API or any third-party CDN (a subtle but real privacy leak most tools ignore)
- No sign-up required
- Works fully offline
- Premium vault sync writes a local JSON file — user controls their own sync layer 
  (Syncthing recommended for full privacy)
- Only external request: one-time license validation on activation
- Visitor analytics via Cloudflare Web Analytics (cookieless, no IP storage)

**Honest limitations:**
- Closed source (license validation backend)
- Paid for unlimited ($9 one-time); free tier limited to 25 bookmarks

Tool: https://squirrel.aditco.in  
Manual + Data & Privacy section: https://squirrel.aditco.in/manual

Disclosing affiliation: I am the developer of this tool.