### PR TITLE
Add CypherESIM in Mobile Data / eSIM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,13 @@ These providers offer apps and services filled with data trackers. Also, most of
 
 Many websites require phone number verification. These services offer a way to receive (and sometimes send) SMS messages in a privacy-focused manner.
 
+
+
+## Mobile Data / eSIM
+
+- [CypherESIM](https://cypheresim.com) — Anonymous travel eSIM with 4G/5G data in 180+ countries. No account, ID, email or phone number; paid in crypto (USDT, BTC, ETH, USDC, XMR).
+
+
 ### No email verification, accepting monero
 - [Crypton](https://crypton.sh/) - Secure SMS Sim Card in the cloud. (Based in Iceland)
 - [Virtualsim](https://virtualsim.net/) - Virtualsim provides physical SIM cards leasing for SMS verifications. (Based in Ukraine)


### PR DESCRIPTION
Adds **CypherESIM** in a new section "Mobile Data / eSIM".

CypherESIM is an anonymous travel eSIM provider — 4G/5G mobile data in 180+ countries; no account, ID, email or phone number; paid in crypto (USDT, BTC, ETH, USDC, XMR).

I propose a separate "Mobile Data / eSIM" section rather than placing under "SMS Verification" because CypherESIM is data-only (no SMS, no phone calls). The category is functionally distinct. Happy to move it to any other section if you'd prefer.

This is a service entry, not an advertisement — factual description, no affiliate links, no promotional language.

**Affiliation:** I am affiliated with CypherESIM (founder), disclosing for transparency.Create a new branch and start a pull request