### PR TITLE
Add CypherESIM in new Mobile Data / eSIM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,13 @@ Many websites require phone number verification. These services offer a way to r
 ### Email verification required, accepting crypto
 - [SmsPVA](https://smspva.com/) - SmsPVA is a service providing a phone number you can send any SMS on and get a text of it. (Based in France)
 
+## Mobile Data / eSIM
+
+Travel eSIM providers offer mobile data plans (4G/5G internet, no SMS, no voice calls) that activate remotely on eSIM-compatible devices. These services let you stay online while traveling without local SIM cards or carrier roaming.
+
+### No KYC, accepting crypto
+- [CypherESIM](https://cypheresim.com) - Anonymous travel eSIM with 4G/5G data in 180+ countries. Paid in USDT, BTC, ETH, USDC, or XMR. No account, ID, email or phone number required. (Operates internationally)
+
 ## Operating Systems
 ### Android
 ⛔ Try to avoid using Google Android or any Android that has been modified and tuned by any manufacturer such as Xiaomi, Huawei, Samsung, etc. Android is an Open Source project - [AOSP - Android Open Source Project](https://source.android.com/) - and it has many versions that will respect the user privacy and data and won't share it with private servers from manufacturers or service providers.


### PR DESCRIPTION
This adds a new top-level section "Mobile Data / eSIM" with **CypherESIM** as the first entry, following the same sub-categorization pattern (KYC + payment) used in "Online Phone Providers".

## Why a separate section

CypherESIM is data-only (no SMS, no voice calls), which is functionally distinct from the existing "Online Phone Providers" entries (all SMS/verification services). Listing it there would mislead users. Travel eSIMs are a growing privacy-relevant category and don't currently have a home in the list.

Happy to move it under "Online Phone Providers" as a sub-section if you'd prefer — but I think a parallel section is structurally cleaner.

## How CypherESIM meets the CONTRIBUTING requirements

- **Privacy Policy** (https://cypheresim.com/privacy-policy) — explicit and short. It matches the FAQ verbatim, names every third party (only two: upstream eSIM connectivity partner + crypto payment processor), and uses no behavioural / advertising tracking.
- **No user tracking** — verified live on 2026-06-18: no Google Analytics, no Google Tag Manager, no Facebook Pixel, no third-party trackers. `window.dataLayer` is undefined; total of 6 scripts on the homepage.
- **No identity data collected** — no email, phone, ID, KYC, or account. The Telegram bot uses only the Telegram-supplied user ID for operation.

## Open-source disclosure

Per CONTRIBUTING, open-source is "very valuable." CypherESIM is **closed-source** (consistent with the other listed phone/SIM services such as Crypton.sh, MoneroSMS, Onlinesim, etc.), because eSIM provisioning integrates with proprietary mobile network operator APIs that cannot be open-sourced.

## Affiliation

I am affiliated with CypherESIM (founder), disclosing for transparency.