### PR TITLE
Add HumbleBee time tracking + Time Tracking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
     - [YouTube](#youtube)
 - [Screen Recording](#screen-recording)
 - [Teamworking Tools](#teamworking-tools)
+- [Time Tracking](#time-tracking)
 - [Translation](#translation)
 - [Uncategorized](#uncategorized)
 - [Utilities](#utilities)
@@ -1443,6 +1444,20 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 > Also using any of these modifications/clients [violates](https://nitter.net/discord/status/1006178587731550208#m) the [Discord ToS](https://discord.com/terms) so, we are not responsible of any suspension or termination of your account **but**, this should [not happen **yet**](https://github.com/GooseMod/GooseMod/wiki/FAQ#is-goosemod-against-discord-tos).
 
 - [See this section for Discord mods and alternative clients](https://github.com/pluja/awesome-privacy/blob/main/README.md#alternative-clientsmodifications-of-discord)
+
+[Back to top 🔝](#contents)
+
+## Time Tracking
+⛔ **Avoid**
+
+Hosted time-tracking services can collect detailed work records, project names, clients, habits and schedules.
+
+- Toggl Track
+- Clockify
+- Harvest
+
+✅ **Instead use**
+- [HumbleBee](https://github.com/grobmeier/humblebee) - Free and open source local-first time tracking with CLI and desktop GUI. Stores records in a local SQLite database.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds a Time Tracking section.

Adds HumbleBee as a local-first, open-source alternative to hosted time-tracking services.

HumbleBee stores records locally in SQLite and does not require a cloud account.
Only users control their data.
No user tracking or similar is added.

The tools website:
https://www.timeandbill.de/en/humblebee/
uses Plausible as an analytics tool.

Humblebee is the full privacy sister project of Time & Bill, which also has very strict privacy rules.