### PR TITLE
Add GhostMeta (in-browser EXIF/GPS/C2PA metadata remover) under Photo Editing > Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [GhostMeta](https://www.ghostmeta.online) - Strip EXIF, GPS and C2PA metadata from images, directly in your browser. Nothing is uploaded.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
This adds **GhostMeta** to the *Web* subsection of **Photo Editing and Management**, right after miniPaint.

GhostMeta removes EXIF, GPS and C2PA Content Credentials from JPEG/PNG images entirely in the browser — the file never leaves the device, and it works offline (you can switch on airplane mode and it still processes). Same in-browser privacy model as the existing miniPaint entry (nothing is sent to a server). The core metadata-stripping is free and needs no signup.

Website: https://www.ghostmeta.online
