### PR TITLE
Add Ghostral (private, verifiable AI chat) under Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ When using cloud-based AI services, the data you input is often collected and st
 
 #### ChatGPT
 
+- [Ghostral](https://ghostral.ai) - Private AI chat that keeps no logs (incognito by default) and signs every reply with a cryptographic receipt you can independently verify. Runs self-hosted models on dedicated GPUs rather than third-party APIs.
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.


### PR DESCRIPTION
Adds [Ghostral](https://ghostral.ai) to the **Artificial Intelligence → ChatGPT** list.

Ghostral is a privacy-focused AI chat in the same vein as the existing **Tinfoil** entry: it keeps no logs (incognito by default) and signs every reply with a cryptographic receipt you can independently verify, running self-hosted models on dedicated GPUs rather than routing prompts to third-party APIs like OpenAI/Anthropic.

- Entry placed alphabetically (before Jan).
- Format matches the surrounding `- [Name](url) - Description.` style.

Thanks for maintaining this list! 🙏