### PR TITLE
Add venice-e2ee-proxy to ChatGPT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
+- [venice-e2ee-proxy](https://github.com/AxLabs/venice-e2ee-proxy) - Run-it-locally proxy that adds end-to-end encryption to Venice.ai API calls. Plug any agent or software without changes — point your OpenAI-compatible client at it and get E2EE with TEE-backed models automatically.
 
 #### AI Coding
 


### PR DESCRIPTION
Adds [venice-e2ee-proxy](https://github.com/AxLabs/venice-e2ee-proxy) — a run-it-locally, open-source proxy that adds end-to-end encryption to Venice.ai API calls. Any OpenAI-compatible agent or software can use it without code changes: just point the client at the proxy and requests are automatically encrypted with verified TEE attestation (Intel TDX + NVIDIA GPU).

Fits the ChatGPT section alongside other privacy-preserving AI tools like PasteGuard, Shimmy, and Tinfoil.