### PR TITLE
Add Floe to File Management and Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ on the DMCrypt kernel module.
 - [Croc](https://github.com/schollz/croc) - Easily and securely send things from one computer to another.
 - [Dat-cp](https://github.com/tom-james-watson/dat-cp) - Copy files between hosts on a network using the peer-to-peer Dat network.
 - [Destiny](https://leastauthority.com/community-matters/destiny/) - Send files directly to the receiver in real-time. Developed for and with HROs as a free Privacy Enhancing Technology alternative.
+- [Floe](https://floe.one/) - Browser and CLI peer-to-peer file transfer over WebRTC. File data is sent directly between peers and never touches a server.
 - [Gokapi](https://github.com/Forceu/Gokapi) - Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported.
 - [Lufi](https://framagit.org/fiat-tux/hat-softwares/lufi) - Let's Upload that FIle — File sharing software.
 - [Localsend](https://localsend.org/) - Share files to nearby devices. Free, open source, cross-platform.


### PR DESCRIPTION
Adds **Floe** to the File Management and Sharing section.

Floe is a browser-native and CLI peer-to-peer file transfer app built on WebRTC. File data is sent directly between peers over an encrypted data channel and never touches a server, which makes it a privacy-respecting alternative for sending files.

- Website: https://floe.one/
- Source: https://github.com/jannskiee/floe