### PR TITLE
Add OpenSnitch to Privacy Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,7 @@ This section is dedicated to some tools that may help users analyze the privacy 
 
 - [Whoami Project](https://github.com/owerdogan/whoami-project) - Whoami provides enhanced privacy, anonymity for Debian and Arch based linux distributions.
 - [BusKill](https://www.buskill.in/) - BusKill is a Dead Man Switch triggered when a magnetic breakaway is tripped, severing a USB connection.
+- [OpenSnitch](https://github.com/evilsocket/opensnitch) - Interactive application firewall for GNU/Linux that helps users detect, monitor, and block unwanted outbound connections.
 
 ### Android
 


### PR DESCRIPTION
OpenSnitch is an open-source application firewall for Linux that allows users to monitor and control outbound connections. It fits well within the Privacy Tools section alongside tools such as NetGuard and RethinkDNS.