### PR TITLE
Add nullsink (AI > ChatGPT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
+- [nullsink](https://nullsink.is/) - Privacy-first, account-less proxy for frontier-model APIs. Mint a prepaid key in your browser, fund it with Monero or Bitcoin, and point the official SDKs at one base URL. No accounts, no IP logging, no request or content retention. AGPL-3.0, self-hostable. [Source](https://github.com/nullsink/nullsink).
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.


### PR DESCRIPTION
Adds **nullsink** to Artificial Intelligence → ChatGPT (alphabetically between LocalAI and ollama).

nullsink is a privacy-first, account-less proxy for frontier-model APIs: mint a prepaid key in your browser, fund it with Monero or Bitcoin, and point the official SDKs at one base URL. No accounts, no IP logging, no request or content retention; payment and key are kept unlinkable; crypto custody is watch-only. AGPL-3.0 and self-hostable.

Substantiating the privacy claims:
- Source: https://github.com/nullsink/nullsink
- Trust model (no-logging, watch-only custody, and what it does *not* protect): https://github.com/nullsink/nullsink/blob/main/docs/trust-model.md
- The site sets no cookies, loads no third-party scripts, and runs no analytics (prerendered static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
