### PR TITLE
Add awesome-dpi-bypass to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,7 +1482,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 [Back to top 🔝](#contents)
 
 ## Utilities
-[awesome-dpi-bypass](https://github.com/ubub111/awesome-dpi-bypass) - A curated directory of modern DPI-evasion utilities, routing cores (Xray, sing-box), and compatible cross-platform client applications.
+- [awesome-dpi-bypass](https://github.com/ubub111/awesome-dpi-bypass) - A curated directory of modern DPI-evasion    utilities, routing cores (Xray, sing-box), and compatible cross-platform client applications.
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
 

--- a/README.md
+++ b/README.md
@@ -1482,6 +1482,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 [Back to top 🔝](#contents)
 
 ## Utilities
+[awesome-dpi-bypass](https://github.com/ubub111/awesome-dpi-bypass) - A curated directory of modern DPI-evasion utilities, routing cores (Xray, sing-box), and compatible cross-platform client applications.
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
 


### PR DESCRIPTION
Hello! I'm proposing to add `awesome-dpi-bypass` to the Utilities section.
It maps out the current ecosystem of advanced anti-censorship tools, cores (Xray, sing-box) and clients to help users protect their network metadata from ISP logging and Deep Packet Inspection (DPI).
The list is open-source, non-commercial and strictly educational. Thank you!