### PR TITLE
Add DailyVox to Notes and Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 
 - [Anytype](https://www.anytype.io/) - An open-source Notion alternative. E2EE, cloud and local network sync, can be self-hosted.
 - [AppFlowy](https://www.appflowy.io/) - Open Source Notion Alternative. You are in charge of your data and customizations.
+- [DailyVox](https://getdailyvox.com) - Free and open-source voice journal for iOS. Transcribes and analyses entries fully on-device — no account, no servers, no data collection ("Data Not Collected" on the App Store).
 - [HedgeDoc](https://hedgedoc.org/) - Formerly CodiMD (community). An awesome platform to write and share markdown.
 - [Joplin](https://github.com/laurent22/joplin) - Note taking and to-do application with synchronisation and encryption capabilities.
 - [Logseq](https://logseq.com/) - A privacy-first alternative to WorkFlowy.


### PR DESCRIPTION
DailyVox is a free, open-source (MIT) voice journal for iOS.

- **Privacy-respecting by architecture:** speech-to-text and all AI analysis run **on-device**; no account, no servers, no data collection (Apple "Data Not Collected" label).
- **Free & open source:** no subscription, no ads — source at https://github.com/intrepidkarthi/dailyvox
- Fits the list's criteria (free, open source, privacy-respecting); slotted alphabetically in **Notes and Tasks → Instead use**.

Site: https://getdailyvox.com