### PR TITLE
Add VidKit to Video Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1552,6 +1552,7 @@ Such programs come filled with trackers and telemetry. You can get a full list o
 - [Olive Video Editor](https://olivevideoeditor.org/) - Free open-source advanced non-linear video editor currently in Alpha state.
 - [OpenCut](https://github.com/OpenCut-app/OpenCut) - [beta] A free, open-source video editor for web, desktop, and mobile.
 - [Shotcut](https://www.shotcut.org/) - Shotcut is a free, open source and simple cross-platform video editor.
+- [VidKit](https://vidkit.eu) - Free, in-browser video compressor and format converter (MP4, MOV, MKV, WebM, MP3, GIF). Files are processed locally and never uploaded — no cookies, no accounts. [Source code](https://github.com/TondaRuzicka/vidkit).
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
### Adding: [VidKit](https://vidkit.eu)

A free, browser-based video **compressor and format converter** (MP4, MOV, MKV, WebM, MP3, GIF).

**Why it fits this list:**
- **Files never leave the device** — all processing runs locally in the browser (WebCodecs, with an ffmpeg.wasm fallback). There is no server that could receive the file.
- **No cookies, no cross-site tracking, no accounts** (only cookieless, aggregate pageview stats).
- **Open source (MIT):** https://github.com/TondaRuzicka/vidkit
- No watermarks, no sign-up, no file-count limits.
- The zero-upload guarantee is enforced by an automated test in the repo.

Added under **Video Editing**, alphabetically after Shotcut.

I'm the author and confirm it meets the list's open-source / privacy criteria.