### PR TITLE
Add Flick to File Management and Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ on the DMCrypt kernel module.
 - [Croc](https://github.com/schollz/croc) - Easily and securely send things from one computer to another.
 - [Dat-cp](https://github.com/tom-james-watson/dat-cp) - Copy files between hosts on a network using the peer-to-peer Dat network.
 - [Destiny](https://leastauthority.com/community-matters/destiny/) - Send files directly to the receiver in real-time. Developed for and with HROs as a free Privacy Enhancing Technology alternative.
+- [Flick](https://github.com/Flick-Corp/flick) - Selfhosted file sharing using short memorable codes, with optional end-to-end encryption, expiring links and no account required. Web UI and CLI.
 - [Gokapi](https://github.com/Forceu/Gokapi) - Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported.
 - [Lufi](https://framagit.org/fiat-tux/hat-softwares/lufi) - Let's Upload that FIle — File sharing software.
 - [Localsend](https://localsend.org/) - Share files to nearby devices. Free, open source, cross-platform.


### PR DESCRIPTION
Adds Flick to File Management and Sharing.
	- Open source (MIT): https://github.com/Flick-Corp/flick
	- Self-hosted, files stay on your own server, optional end-to-end encryption or password
	- System of groups for organization/enterprise
	- No trackers/analytics on the project site
	- Replaces WeTransfer and others.