### PR TITLE
Add free/private browser calorie & macro tracker (Fitness & Health → Food)

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 ### Food
 - [OpenFoodFacts](https://world.openfoodfacts.org/) - Open Food Facts is a food products database made by everyone, for everyone. You can use it to make better food choices.
     - [OFF Apps](https://world.openfoodfacts.org/open-food-facts-mobile-app)
+- [Calorie & Macro Tracker](https://atlas-asittley.github.io/calorie-tracker/) - A free, private calorie and macro tracker that runs entirely in your browser. No account and no subscription; all data stays on your device (local storage). Uses the open Open Food Facts database, with barcode scanning.
 
 ### Menstrual cycle trackers
 - [🤖](#icons) [Bluemoon](https://gitlab.com/ngrob/bluemoon-android) - Open source, privacy friendly menstruation tracking app. Your period, your data!


### PR DESCRIPTION
Adds a privacy-respecting calorie & macro tracker to the **Food** subsection.

- **Runs entirely in the browser**, no app to install
- **No account, no subscription**
- **All data stays on the device** (browser local storage) — nothing is uploaded to a server
- Uses the open **Open Food Facts** database (already listed here), with barcode scanning

It fits the section's spirit (a private alternative to data-harvesting trackers like MyFitnessPal), and is in the same vein as existing browser/local-first entries such as Poppy and Euki. Thanks for maintaining this list!