### PR TITLE
Add Ovumcy (self-hosted menstrual cycle tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 ### Menstrual cycle trackers
 - [🤖](#icons) [Bluemoon](https://gitlab.com/ngrob/bluemoon-android) - Open source, privacy friendly menstruation tracking app. Your period, your data!
 - [🤖](#icons) [Drip](https://dripapp.org/) - Menstrual cycle and fertility tracking. Everything you enter stays on your device.
+- [Ovumcy](https://github.com/ovumcy/ovumcy-web) - Self-hosted, privacy-first menstrual cycle tracker you run yourself. Server-rendered web app, SQLite/Postgres, Docker-ready, no telemetry, open data export. AGPL-3.0.
 - [Euki](https://eukiapp.org/) - The period tracker that doesn’t track you. 
 - [🤖](#icons) [log28](https://github.com/wildeyedskies/log28) - a (very) simple no-frills period tracker for Android.
 - [🤖](#icons) [Periodical](https://github.com/arnowelzel/periodical) - A calendar to track your menstruation and calculate possible fertile days


### PR DESCRIPTION
Adds **Ovumcy** to *Fitness and Health -> Menstrual cycle trackers*.

Ovumcy is a self-hosted, privacy-first menstrual cycle tracker: a server-rendered web app you run on your own server, so your health data stays on infrastructure you control. The two existing entries in this subsection are device-local Android apps; Ovumcy adds the self-hosted / multi-device option.

- Source: https://github.com/ovumcy/ovumcy-web (AGPL-3.0)
- Site: https://ovumcy.com
- SQLite by default, Postgres optional, Docker images provided, open data export (JSON/CSV)

Requirements:
- [x] Clear privacy-oriented / own-your-data policy (core design goal)
- [x] No user-tracking on project website (no third-party scripts/analytics on ovumcy.com)
- [x] Open source (AGPL-3.0)
