### PR TITLE
Add .env Deep Sanitizer to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Opt for open-source and P2P alternatives that prioritize data privacy, eliminate
 [Back to top 🔝](#contents)
 
 ## Developer Tools
+- [.env Deep Sanitizer](https://aarunyaapps.com/env-sanitizer) - Redacts secrets from .env, YAML, and JSON config files entirely in your browser. Zero uploads, no server processing. Detects API keys, database URLs, JWT secrets, AWS credentials, and 15+ other secret patterns.
 - [Beekeeper Studio](https://www.beekeeperstudio.io) - Open Source SQL Editor and Database Manager with a privacy commitment in their mission statement.
 
 ### IDEs


### PR DESCRIPTION
## Description

Adds [.env Deep Sanitizer](https://aarunyaapps.com/env-sanitizer) — a browser-based tool that redacts secrets from .env, YAML, and JSON config files without uploading them anywhere.

## Why it belongs here

This tool fits the privacy-first ethos of this list:
- **Zero uploads** — all processing happens in the browser tab via client-side JavaScript
- **No account required** — no sign-up, no email, no session tracking
- **Open to inspection** — users can open DevTools → Network tab and verify no requests are made during redaction
- **Common use case** — developers need to sanitize .env files before sharing with contractors or committing .env.example templates

Detects 15+ secret patterns: API keys, database URLs, JWT secrets, AWS credentials, Stripe keys, Twilio tokens, and more.