### PR TITLE
Add Off Grid AI Desktop to Artificial Intelligence > ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) - Private, local-first macOS app that runs LLM chat, image generation, and dictation entirely on-device; nothing leaves the machine.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.


### PR DESCRIPTION
## What
Adds [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) to **Artificial Intelligence > ChatGPT**, alongside Jan, LocalAI, and ollama.

## About
Open-source (AGPL-3.0) macOS app that runs LLM chat, image generation, and dictation entirely on-device. No account, no telemetry, no cloud - nothing leaves the machine.

Disclosure: I'm involved with the project.