### PR TITLE
Add Brianni AI to ChatGPT alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
+- [Brianni AI](https://brianni.ai/) - Web-based ChatGPT-style chat for GPT, Claude, and Gemini that uses user-held keys, on-device PII masking, and a client-attested AWS Nitro Enclave; the enclave source is Apache-2.0 licensed.
 - [Open WebUI](https://openwebui.com) - Self-hosted web interface for Ollama and other local models that gives you a private ChatGPT-style chat. BSD-3 licensed.
 - [LibreChat](https://librechat.ai) - Self-hosted chat interface that connects many AI models behind one private UI you control. Open source, MIT licensed.
 


### PR DESCRIPTION
## Summary

Adds `Brianni AI` to the `Artificial Intelligence > ChatGPT` section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] No new section added; the existing `ChatGPT` section is already in the Table of Contents.
- [x] Project has a clear privacy / own-your-data policy: https://brianni.ai/privacy
- [x] Project website loads no third-party trackers; the public privacy page states no analytics, pixels, tag managers, or session replay.
- [x] Source or repo link is provided: https://github.com/zeemudia/brianni-enclave
- [x] License is stated: the public enclave source is Apache-2.0 licensed.
- [x] Project is maintained.

Notes for review: Brianni AI is a hosted web app rather than a fully open-source local tool, so I worded the entry narrowly around its privacy architecture and public enclave source rather than claiming the full service is open source.
