### PR TITLE
mark AuroraDroid F-Droid client as unmaintained, and fix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@
 ✅  **Instead use**
 - [F-Droid](https://f-droid.org/) - F-Droid is an installable catalogue of FOSS (Free and Open Source Software) applications for the Android platform.
 	- [Droid-ify](https://github.com/Iamlooker/Droid-ify) - Lightweight F-Droid client with Material UI.
+	- [Aurora Droid](https://github.com/whyorean/AuroraDroid) [💀](#icons) - Aurora Droid is a modern FOSS client for F-Droid.
 	- [Foxy Droid](https://github.com/kitsunyan/foxy-droid) [💀](#icons) - Unofficial F-Droid client in the style of the classic one.
 - [FossDroid](https://fossdroid.com/) - Fossdroid's aim is to promote free and open source apps on the Android platform: newest, trendiest and the most popular ones.
 - [SkyDroid](https://skydroid.app/) - Decentralized App Store for Android

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@
 ✅  **Instead use**
 - [F-Droid](https://f-droid.org/) - F-Droid is an installable catalogue of FOSS (Free and Open Source Software) applications for the Android platform.
 	- [Droid-ify](https://github.com/Iamlooker/Droid-ify) - Lightweight F-Droid client with Material UI.
-	- [Aurora Droid](https://auroraoss.com/download/#aurora-droid) - Aurora Droid is a modern FOSS client for F-Droid.
 	- [Foxy Droid](https://github.com/kitsunyan/foxy-droid) [💀](#icons) - Unofficial F-Droid client in the style of the classic one.
 - [FossDroid](https://fossdroid.com/) - Fossdroid's aim is to promote free and open source apps on the Android platform: newest, trendiest and the most popular ones.
 - [SkyDroid](https://skydroid.app/) - Decentralized App Store for Android


### PR DESCRIPTION
1. the current link is 404
2. the current link actually points towards Aurora Store, which is a different thing and already linked as an alternative Play store front end.
3. Has not received updates for 6 years. It is clearly no longer maintained. So either we update the link to the actual Aurora Droid: https://github.com/whyorean/AuroraDroid

Or simply remove it instead of recommending unmaintained software. Either way the current link is wrong x2.

<!-- Thanks for contributing. Keep this PR to one topic. See misc/Contributing.md. -->

## Summary

<!-- One line: what you add and the section it goes under. -->
Adds `<Service or Section>` to the `<Section>` section.

N/A, already has a section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not
