### PR TITLE
Add Cleanor Tools (on-device, browser-based image tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [Fawkes](https://github.com/Shawn-Shan/fawkes) [💀](#icons) - privacy preserving tool against facial recognition systems.
   - [CloakMe](https://github.com/pluja/CloakMe) [💀](#icons) - Web interface for Fawkes algorithm.
 - [ImageScrubber](https://github.com/everestpipkin/image-scrubber) - A friendly browser-based tool for anonymizing photographs taken at protests ([hosted version provided by everestpipkin](https://everestpipkin.github.io/image-scrubber/)).
+- [Cleanor Tools](https://cleanor.app/tools) - Browser-based image converters and compressors (WebP, AVIF, PNG, JPEG and more) that run entirely on your device; files are never uploaded and no account is required ([open-source engine](https://github.com/cleanor-app/browser-image-tools)).
 
 ### Text
 - [Stegcloak](https://stegcloak.surge.sh/) - Hide secrets with invisible characters in plain text securely using passwords ([repo](https://github.com/kurolabs/stegcloak)).


### PR DESCRIPTION
Adds **Cleanor Tools** under **Images**.

- Browser-based image converters/compressors (WebP, AVIF, PNG, JPEG, and more) that run **entirely on the user's device** — files are never uploaded and no account is required, which fits this list's privacy focus (same spirit as the existing browser-based ImageScrubber entry).
- Open-source engine: https://github.com/cleanor-app/browser-image-tools (MIT).

Single-line addition, formatting matches the section.