### PR TITLE
Add Prevail to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 - [Open WebUI](https://openwebui.com) - Self-hosted web interface for Ollama and other local models that gives you a private ChatGPT-style chat. BSD-3 licensed.
 - [LibreChat](https://librechat.ai) - Self-hosted chat interface that connects many AI models behind one private UI you control. Open source, MIT licensed.
+- [Prevail](https://github.com/fru-dev3/prevail-desktop) - Local-first AI "life OS" desktop app for macOS and Windows: any model per life-domain over a plain-markdown vault on your machine, fully offline with Ollama. Open source, GPL-3.0 licensed.
 
 #### AI Coding
 


### PR DESCRIPTION
## Summary

Adds `Prevail` to the `Artificial Intelligence > ChatGPT` section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents) *(no new section)*
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (entry links straight to the source repo)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not

Prevail is a local-first desktop app (Tauri 2): all state is plain markdown/JSON on your machine, no account, no telemetry by default, works fully offline with local Ollama models. Open source, GPL-3.0.