### PR TITLE
Add EXIF Remover (Presend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [Fawkes](https://github.com/Shawn-Shan/fawkes) [💀](#icons) - privacy preserving tool against facial recognition systems.
   - [CloakMe](https://github.com/pluja/CloakMe) [💀](#icons) - Web interface for Fawkes algorithm.
 - [ImageScrubber](https://github.com/everestpipkin/image-scrubber) - A friendly browser-based tool for anonymizing photographs taken at protests ([hosted version provided by everestpipkin](https://everestpipkin.github.io/image-scrubber/)).
+- [EXIF Remover](https://presendapp.netlify.app/tools/exif-remover.html) - Browser-based tool to strip EXIF metadata (GPS, camera model, timestamps) from a photo before sharing it. No upload, no server involved.
 
 ### Text
 - [Stegcloak](https://stegcloak.surge.sh/) - Hide secrets with invisible characters in plain text securely using passwords ([repo](https://github.com/kurolabs/stegcloak)).


### PR DESCRIPTION
Adds a free, browser-based EXIF metadata remover — processes images entirely client-side, no upload, no account. Similar in spirit to ImageScrubber already listed in this section.