### PR TITLE
Add Humla to Speech to Text (Apps and services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [Humla](https://humla.team) - Meeting notes for macOS that record with no bot joining the call and transcribe on-device with Whisper, then write an AI summary fusing your notes with the transcript. Local-first, no telemetry, open source (MIT).
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
Adds [Humla](https://humla.team) under **AI → Speech to Text → Apps and services**, alongside OpenWhispr.

Humla is a free, open-source (MIT) macOS meeting-notes app built privacy-first: it records your mic and the call's system audio through macOS with no bot joining the call, and can transcribe and summarize entirely **on-device** with Whisper (or a bring-your-own API key). No account, no telemetry, local SQLite storage — a good fit for this list.

- Site: https://humla.team
- Source: https://github.com/michaelwilhelmsen/humla