### PR TITLE
Add NULLA (local-first AI agent with offline-verifiable action receipts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 - [Open WebUI](https://openwebui.com) - Self-hosted web interface for Ollama and other local models that gives you a private ChatGPT-style chat. BSD-3 licensed.
 - [LibreChat](https://librechat.ai) - Self-hosted chat interface that connects many AI models behind one private UI you control. Open source, MIT licensed.
+- [NULLA](https://github.com/Parad0x-Labs/nulla-local) - Local-first AI agent that runs fully on your own machine and signs an offline-verifiable receipt of each action; never phones home. MIT licensed, self-hostable, Alpha.
 
 #### AI Coding
 


### PR DESCRIPTION
Adds NULLA under Artificial Intelligence -> ChatGPT (local / self-hosted alternatives).

NULLA is a local-first AI agent that runs fully on the user's machine and never phones home. It signs an offline-verifiable receipt of each action (what it claimed vs. what actually ran), so a third party can verify what the agent did without trusting a server. MIT-licensed, self-hostable, Alpha.

Repo: https://github.com/Parad0x-Labs/nulla-local
