### PR TITLE
Add Family Trip Planner — offline, zero-data itinerary tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [🤖](#icons) [KashCal](https://github.com/KashCal/KashCal) - Offline-first Android calendar with iCloud/CalDAV sync, full-text search, recurring events, and home screen widget. Apache 2.0 licensed.
 - [Nextcloud Calendar](https://apps.nextcloud.com/apps/calendar) - Calendar app for Nextcloud with CalDAV support. Self-hostable.
 - [Proton Calendar](https://proton.me/calendar) - End-to-end encrypted calendar from Proton. Part of the Proton privacy ecosystem.
+- [Family Trip Planner](https://ordinarymantrying.com/tools/family-schedule.html) - Browser-based family itinerary planner. No account, no server, no tracking. All data stays in localStorage only — nothing ever leaves your device. Export schedule as image or print directly.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What's being added

[Family Trip Planner](https://ordinarymantrying.com/tools/family-schedule.html) added to the **Calendar** section.

## Why it fits awesome-privacy

- **No account required** — open and use instantly
- **Zero server-side storage** — all data stays in localStorage, nothing sent to any server
- **No tracking, no analytics, no ads**
- **Export as image or print** — share your schedule without uploading anywhere
- Works fully offline after first load

## Features

- Day-by-day family itineraries with time slots
- Family members, packing lists, emergency contacts
- Photo uploads (stored locally only)
- Dark / light theme, bilingual EN / 中文

A privacy-respecting alternative for families who want to plan trips without sending schedule data to Google Calendar or cloud services.