### PR TITLE
Add Fidalo to Personal Finances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,6 +1137,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ### Full Featured Financial Management
 
 - [Actual](https://actualbudget.org) - Super fast and privacy-focused app for managing your finances.
+- [Fidalo](https://fidalo.co) - Local-first net worth, budget and portfolio tracker. No account, no bank connection, no telemetry; data stays in your browser and encrypted backups go to storage you control. Open source (AGPL). ([Source Code](https://github.com/fidalodev/fidalo))
 - [Firefly III](https://www.firefly-iii.org/) - A free and open source personal finance manager.
 - [GnuCash](https://gnucash.org/) - GnuCash is personal and small-business financial-accounting software, freely licensed under the GNU GPL and available for GNU/Linux, BSD, Solaris, Mac OS X and Microsoft Windows.
 - [Sure](https://github.com/we-promise/sure) - Open Source and secure OS for your personal finances. Community maintained fork of the archived [Maybe](https://github.com/maybe-finance/maybe) project.


### PR DESCRIPTION
## Summary

Adds `Fidalo` to the `Personal Finances` section.

Fidalo is a free, open-source (AGPL) local-first personal finance app: net worth, budget and investment portfolio tracking that runs entirely in the browser, with no account and no bank connection. Data stays on the device and encrypted backups go to storage the user controls.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not