### PR TITLE
Add Mood trackers subsection to Fitness and Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 	- [Food](#food)
 	- [Menstrual cycle trackers](#menstrual-cycle-trackers)
 	- [Medical health](#medical-health)
+	- [Mood trackers](#mood-trackers)
 - [Fonts](#fonts)
 - [Forms](#forms)
 - [Games](#games)
@@ -590,6 +591,9 @@ If you need an app for **menstrual cycle tracking** please don't use any apps li
 
 ### Medical health
 - [Fasten](https://github.com/fastenhealth/fasten-onprem) - Fasten is an open-source, self-hosted, personal/family electronic medical record aggregator, designed to integrate with 1000's of insurances/hospitals/clinics.
+
+### Mood trackers
+- [🤖](#icons) [SoulSync](https://github.com/Antimatter543/mood-tracker) - Free mood tracker that stores everything on-device in SQLite, with no account and no cloud sync. Replaces subscription cloud mood trackers like Daylio. GPL-3.0.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Summary

Adds a new `Mood trackers` subsection to the `Fitness and Health` section (mirrors the existing `Menstrual cycle trackers` subsection), listing SoulSync.

SoulSync is a free, open-source mood tracker for Android. Everything is stored 100% on-device in SQLite, no account, no cloud sync, no ads, no subscription, with full data export. It replaces subscription/cloud-tethered mood trackers like Daylio.

- Repo: https://github.com/Antimatter543/mood-tracker
- Privacy policy: https://raeduslabs.com/soulsync-privacy.html
- License: GPL-3.0, Android only (marked with the 🤖 icon)
- No third-party trackers on the app's site/store listing

Disclosure: we maintain this app (built by our founder).

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not