### PR TITLE
Add Litlyx to web analytics alternatives list

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
 - [Umami](https://umami.is/) - A simple, fast, website analytics alternative to Google Analytics.
 - [Unidentified Analytics](https://unidentifiedanalytics.web.app/) - Naive ip-based tracking that works everywhere (web, command-line, email, etc). No account required. Developer friendly.
 - [Rybbit](https://rybbit.io) - Open-source and privacy-friendly alternative to Google Analytics that is 10x more intuitive.
+- [Litlyx](https://litlyx.com) - [Open source](https://github.com/litlyx/litlyx), cookieless web analytics alternative to Google Analytics. Self-hostable via Docker, GDPR-compliant, stores no IP addresses or personal data, and requires no consent banner.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Add a privacy first alternative to google analytics in the analytics section

<!-- Thanks for contributing. Keep this PR to one topic. See misc/Contributing.md. -->

## Summary

<!-- One line: what you add and the section it goes under. -->
Adds `Litlyx Abalytics` to the `Analytics` section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not
