### PR TITLE
Add Nika to AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code) - Cline fork with some improvements; community successor to the discontinued Roo Code.
 - [OpenCode](https://github.com/anomalyco/opencode/) - The open source coding agent. Connect local models or any providers of your choice.
 - [Aider](https://aider.chat) - Terminal AI pair programmer that edits code in your local git repository using your own API keys. Apache-2.0 licensed.
+- [Nika](https://github.com/supernovae-st/nika) - Workflow engine for AI that runs fully offline with local models (Ollama, llama.cpp, vLLM): workflows are plain YAML files statically checked before execution, with tamper-evident run traces. AGPL-3.0 licensed.
 - [Tabby](https://tabby.tabbyml.com) - Self-hosted code completion assistant that runs on your own hardware as an alternative to GitHub Copilot. Apache-2.0 licensed.
 
 #### Text to Speech


### PR DESCRIPTION
One line in AI Coding (house format matched — license stated like the Aider/Tabby neighbors). Nika is a workflow engine for AI that runs fully offline with local models (Ollama, llama.cpp, vLLM — the mock path needs zero keys and zero network): workflows are plain reviewable YAML files, statically checked before execution (schema, permits, cost), leaving tamper-evident traces after. Nothing leaves the machine unless a workflow explicitly declares it — the privacy angle is structural, not a setting. AGPL-3.0. Disclosure: I am the author (first-party submission).