### PR TITLE
Add PrivacyScrubber — client-side PII sanitizer for AI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
+- [PrivacyScrubber](https://privacyscrubber.com) - 100% browser-based PII sanitizer for AI prompts. Redacts names, emails, phones, and IDs before sending to ChatGPT/Claude/Gemini. Works offline (airplane mode verified). No server, no storage.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.
 - [Tinfoil](https://tinfoil.sh/) - Verifiably private AI Chat and OpenAI-compatible inference in the cloud. Uses NVIDIA confidential computing and open source code pinned to a transparency log for end-to-end verifiability.
 - [Open WebUI](https://openwebui.com) - Self-hosted web interface for Ollama and other local models that gives you a private ChatGPT-style chat. BSD-3 licensed.


### PR DESCRIPTION
What it does: PrivacyScrubber is a 100% client-side PII sanitizer specifically designed for AI workflows. Users paste documents or text, it detects and replaces PII with tokens ([NAME_1], [EMAIL_1] etc.), and they paste the clean version into any AI model. A "reverse scrub" maps AI responses back to the originals.

Why it belongs here: Zero-server architecture (all processing locally in-browser); Airplane Mode verified; No data stored, logged, or transmitted.

<!-- Thanks for contributing. Keep this PR to one topic. See misc/Contributing.md. -->

## Summary

Adds PrivacyScrubber to the ChatGPT section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not