### PR TITLE
Add OnDevicePDF to Office section

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 
  	- [dSheets](https://dsheets.new): decentralized alternative to Excel and Google Sheets.
 - [Grist](https://www.getgrist.com) - Self-hostable spreadsheet and database hybrid for organizing data, as an open source Airtable alternative. Apache-2.0 licensed.
+- [OnDevicePDF](https://www.ondevicepdf.com) - Free browser-based PDF toolkit (merge, split, compress, OCR, sign, redact and more). 22 of its 23 tools process files entirely on-device with no upload or account; the one exception (advanced PDF Editor) uses a temporary auto-deleted backend and is [disclosed per-tool](https://www.ondevicepdf.com/data-handling). Closed source.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## What
Adds [OnDevicePDF](https://www.ondevicepdf.com) to the **Office** section — a free, browser-based PDF toolkit (merge, split, compress, OCR, sign, redact, convert and more).

## Why it fits this list
- 22 of its 23 tools process files entirely on-device (WebAssembly / JS in the browser) — no upload, no account, no server retention.
- The one exception (a few advanced PDF Editor operations) uses a temporary, auto-deleted backend, and this is transparently disclosed on a per-tool [data-handling page](https://www.ondevicepdf.com/data-handling) rather than hidden behind a '100% local' claim.
- No tracking of document contents; works offline after first load (PWA).
- The entry notes it is closed source, per the list's convention of flagging that.

## Disclosure
I'm the developer of OnDevicePDF — submitting my own project, so feel free to hold it to a higher bar. Happy to adjust the description or placement.