### PR TITLE
Add Slay PDF to Office tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 	- [Ddocs](https://ddocs.new): privacy-enhancing alternative to google docs: onchain, end-to-end encrypted, and decentralized. 
  	- [dSheets](https://dsheets.new): decentralized alternative to Excel and Google Sheets.
 - [Grist](https://www.getgrist.com) - Self-hostable spreadsheet and database hybrid for organizing data, as an open source Airtable alternative. Apache-2.0 licensed.
+- [Slay PDF](https://slaypdf.com/) - AGPL-3.0 local PDF editor and Adobe Acrobat alternative that runs in the browser; [source](https://github.com/emileakbarzadeh/slay-pdf).
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Summary
Adds Slay PDF to the Office section.

Slay PDF is an AGPL-3.0 local PDF editor and Adobe Acrobat alternative that runs in the browser. The entry links the live app and source repository.

## Affiliation
I am associated with the project.

## Checklist
- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not