### PR TITLE
Add Soufflé to Speech to Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - **Apps and services**
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
+	- [Soufflé](https://github.com/damione1/souffle) - Private, on-device speech-to-text app for macOS: dictation with auto-paste, meeting transcription with live speaker separation, and local AI summaries. Nothing leaves your Mac. MIT licensed.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.
 
 #### Image Generation

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - **Apps and services**
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
+	- [Soufflé](https://github.com/damione1/souffle) - On-device dictation and meeting transcription for Apple Silicon Macs, with local speaker separation and AI summaries, as a GPL-3.0 alternative to cloud transcription services like Otter.ai.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.
 
 #### Image Generation


### PR DESCRIPTION
## Summary

Adds `Soufflé` to the `Artificial Intelligence > Speech to Text` section.

[Soufflé](https://github.com/damione1/souffle) is a private, on-device speech-to-text app for macOS (Apple Silicon): dictation with auto-paste, meeting transcription with live speaker separation, and local AI summaries. Nothing leaves the machine.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] N/A, added to the existing Speech to Text section (no new section)
- [x] Project has a clear privacy / own-your-data policy (fully on-device, no cloud, no accounts, no API keys)
- [x] Project website loads no third-party trackers (the project link is its GitHub repo)
- [x] Source or repo link is provided
- [x] License is stated (MIT)
- [x] Project is maintained