### PR TITLE
Add ClipBridge to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,6 +1546,7 @@ Odysee website contains some trackers and is a heavy site. You can use these alt
 [Back to top 🔝](#contents)
 
 ## Utilities
+- [ClipBridge](https://github.com/andreasserfilippi/clipbridge) - Self-hosted, open source clipboard sync between iPhone, Windows, and Mac; you deploy your own backend, nothing routed through a third party.
 - [Deskreen](https://github.com/pavlobu/deskreen) - Turn any device into a secondary screen for your computer.
 - [Loggit](https://loggit.net) - Simple and Encrypted Life Tracking & Logging.
 


### PR DESCRIPTION
Adds ClipBridge under Utilities.

- Clear own-your-data policy: each user deploys their own backend (Vercel + Redis + Pusher), nothing shared or centralized between users
- Fully open source, MIT licensed
- No tracking of any kind; the only network calls are to the user's own deployment