### PR TITLE
Add Vocalinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.
+- [Vocalinux](https://github.com/jatinkrmalik/vocalinux) - Offline voice dictation for Linux. Local speech recognition with whisper.cpp, Whisper, or VOSK; types into any app on X11 and Wayland.
 
 #### Image Generation
 


### PR DESCRIPTION
Adding Vocalinux under Speech to Text, in Apps and services.

It's a GPLv3 cross-distro Linux desktop app for offline dictation. Recognition stays on the machine (whisper.cpp by default, plus Whisper/VOSK/Remote API options) and injects text into whatever app is focused, on X11 or Wayland.

I'm the maintainer. Happy to shorten or reword the line if you want it tighter.