### PR TITLE
Add Tura to AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [OpenCode](https://github.com/anomalyco/opencode/) - The open source coding agent. Connect local models or any providers of your choice.
 - [Aider](https://aider.chat) - Terminal AI pair programmer that edits code in your local git repository using your own API keys. Apache-2.0 licensed.
 - [Tabby](https://tabby.tabbyml.com) - Self-hosted code completion assistant that runs on your own hardware as an alternative to GitHub Copilot. Apache-2.0 licensed.
-- [Tura](https://github.com/Tura-AI/tura) - Local-first open-source coding agent with CLI, TUI, desktop, and web interfaces; supports local models and user-controlled OpenAI-compatible providers. AGPL-3.0 licensed.
+- [Tura](https://github.com/Tura-AI/tura) - Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it (AGPL-3.0).
 
 #### Text to Speech
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [OpenCode](https://github.com/anomalyco/opencode/) - The open source coding agent. Connect local models or any providers of your choice.
 - [Aider](https://aider.chat) - Terminal AI pair programmer that edits code in your local git repository using your own API keys. Apache-2.0 licensed.
 - [Tabby](https://tabby.tabbyml.com) - Self-hosted code completion assistant that runs on your own hardware as an alternative to GitHub Copilot. Apache-2.0 licensed.
+- [Tura](https://github.com/Tura-AI/tura) - Local-first open-source coding agent with CLI, TUI, desktop, and web interfaces; supports local models and user-controlled OpenAI-compatible providers. AGPL-3.0 licensed.
 
 #### Text to Speech
 


### PR DESCRIPTION
## Summary

Adds Tura to the AI Coding section.

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Benchmark details and reproducibility artifacts: https://turaai.net/benchmark

The listing links directly to the AGPL-3.0 source repository. Tura supports local models and user-controlled OpenAI-compatible providers, which is why it fits this privacy-focused section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents) — not applicable; this uses the existing AI Coding section
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not

## Disclosure

I am affiliated with the Tura project. AI assistance was used to research the contribution rules and prepare this update; the final links, claims, checklist, and diff were manually verified.