### PR TITLE
Add LocalMode to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Jan](https://github.com/janhq/jan) - Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Facebook's LLaMA model in pure C/C++ so it can run locally on a CPU.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - Self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware.
+- [LocalMode](https://github.com/LocalMode-AI/LocalMode) - Open-source (MIT) toolkit for running AI in the browser (LLM chat, embeddings, speech, and vision) with no servers or API keys, so prompts and data never leave your device; a local-first alternative to cloud AI APIs.
 - [ollama](https://github.com/jmorganca/ollama) - Get up and running with Llama 2 and other large language models locally.
 - [PasteGuard](https://github.com/sgasser/pasteguard) - Privacy proxy for LLM APIs that masks PII and secrets before they reach cloud providers. Self-hosted, OpenAI-compatible, and restores original data in responses.
 - [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Privacy-focused AI inference server with OpenAI API compatibility, zero cloud dependencies, and local model processing.


### PR DESCRIPTION
## Summary

Adds `LocalMode` to the `Artificial Intelligence` section, alphabetically among the local ChatGPT alternatives.

LocalMode is an open-source (MIT) toolkit for running AI entirely in the browser (LLM chat, embeddings, speech, and vision) with no servers and no API keys, so prompts and data never leave the user's device. It is a local-first alternative to cloud AI APIs.

- Repo (open source): https://github.com/LocalMode-AI/LocalMode
- License: MIT
- Platform: any modern browser (WebGPU with a WebAssembly fallback); works offline after the first model download

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents) — N/A, added to the existing **Artificial Intelligence** section
- [x] Project has a clear privacy / own-your-data policy (all inference is client-side; data never leaves the device, and the core ships a strict no-telemetry policy)
- [x] Project website loads no third-party trackers
- [x] Source or repo link is provided
- [x] License is stated (MIT)
- [x] Project is maintained
