### PR TITLE
Add LokalBot to Speech to Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [LokalBot](https://github.com/stevyhacker/lokalbot) - On-device meeting notes, dictation, and searchable work memory for macOS; a GPL-3.0 alternative to cloud transcription tools with no account or telemetry.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
## Summary

Adds LokalBot to the Artificial Intelligence → Speech to Text → Apps and services section.

LokalBot is a GPLv3 macOS app for on-device meeting notes, dictation, and searchable work memory. Its built-in transcription, summarization, search, and writing features run on the Mac; it has no LokalBot account, analytics SDK, telemetry backend, or hosted AI service. Optional network paths and remote backends are documented transparently.

Disclosure: I am LokalBot's author.

Repository: https://github.com/stevyhacker/lokalbot

Privacy details: https://www.lokalbot.com/privacy

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] No new section was added, so a Contents update is not required
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained
