### PR TITLE
Add Fotoback to third-party services list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ### Third-party
 - [Crypt.ee](https://crypt.ee/) - A private and encrypted place for all your photos, documents, notes and more.
 - [Ente](https://ente.io/) - End-to-end encrypted storage for photos and videos. Open source, [audited](https://ente.io/blog/cryptography-audit/) independently.
+- [Fotoback](https://fotoback.app/) - End-to-end encrypted iPhone photo backup with automatic background sync. Photos are analysed on-device and never used to train AI. Includes an AI baby growth timeline and smart wardrobe organiser. iOS, freemium.
 - [Stingle Photos](https://stingle.org/) - Open source solution that provides strong security, privacy and encryption to backup your photos.
 
 ### Local


### PR DESCRIPTION
<!-- Thanks for contributing. Keep this PR to one topic. See misc/Contributing.md. -->

## Summary

<!-- One line: what you add and the section it goes under. -->
Adds Fotoback - E2E encrypted iPhone photo backup to `Photo Storage` to the `Third-party` section.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [ ] Source or repo link is provided
- [ ] License is stated
- [ ] Project is maintained, or flagged with 💀 if not
