### PR TITLE
Add ZK Relay to Pastebin and Secret Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [Yopass](https://github.com/jhaals/yopass) - Secure sharing of secrets, passwords and files.
 - [scrt.link](https://scrt.link) - Share a secret. End-to-end encrypted. Ephemeral. Open-source.
 - [dele-to](https://dele.to) - Open Source. Modern app to share sensitive credentials and secrets securely with client-side AES-256 encryption, zero-knowledge architecture, and automatic self-destruction.
+- [ZK Relay](https://github.com/Git-on-my-level/zk-relay) - Self-hosted zero-knowledge secret and file sharing for people and agents, with client-side encryption and agent-safe receive. MIT licensed.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
<!-- Thanks for contributing. Keep this PR to one topic. See misc/Contributing.md. -->

## Summary

Adds [ZK Relay](https://github.com/Git-on-my-level/zk-relay) to the Pastebin and Secret Sharing section.

Self-hosted zero-knowledge secret/file sharing (Yopass-style) with client-side encryption. Agent links return preflight instructions instead of ciphertext, so LLM agents can receive secrets without dumping plaintext into transcripts. MIT licensed. Demo: https://zkr.scalingforever.com

Disclosure: I maintain ZK Relay.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents) — N/A (existing section)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not


Made with [Cursor](https://cursor.com)