### PR TITLE
Add Dictee app to the list of services

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ When using cloud-based AI services, the data you input is often collected and st
 	- [ParakeetTDT](https://parakeettdt.com/) - Efficient audio transcription. Convert speech to text with unprecedented speed and accuracy using NVIDIA advanced AI speech recognition model.
 
 - **Apps and services**
+	- [Dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation for Linux desktops. Works offline with local models, 25+ languages, automatic translation, speaker diarization.
 	- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) - Voice-to-text dictation and productivity app with AI agents, meeting transcription, notes, and local/cloud speech recognition. Privacy-first and available cross-platform. Open source alternative to wisprflow.
 	- [Sasayaki](https://github.com/pluja/sasayaki) - Tiny android dictation app that turns speech into clear writing.
 	- [Speaches](https://github.com/speaches-ai/speaches) - OpenAI API-compatible server supporting streaming transcription, translation, and speech generation.


### PR DESCRIPTION
Dictee is a push-to-talk voice dictation app for the Linux desktop. Speech recognition runs entirely on the machine: no audio leaves the device, no account, no API key.

Why it fits this section:
- Offline by design, local models only (Parakeet, Vosk, Whisper, Canary, Nemotron)
- Open source, GPL-3.0
- No tracking on the project page, which is the GitHub repository itself

The "Apps and services" list currently has one Windows and macOS app, one Android app and one server, but no Linux desktop application. The "Models" list right above already includes ParakeetTDT, which is the engine Dictee runs by default.

Packaged for Debian, Ubuntu, Fedora and Arch, with a KDE Plasma widget and a Qt configuration tool.

<!-- Thanks for contributing. Keep this PR to one topic. See misc/Contributing.md. -->

## Summary

<!-- One line: what you add and the section it goes under. -->
Adds `<Service or Section>` to the `<Section>` section.

## Checklist

- [ ] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents)
- [ ] Project has a clear privacy / own-your-data policy
- [ ] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [ ] Source or repo link is provided
- [ ] License is stated
- [ ] Project is maintained, or flagged with 💀 if not
