### PR TITLE
Adds Ciphera Pulse to Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [Ackee](https://ackee.electerious.com/) - Self-hosted website analytics.
 - [Aptabase](https://aptabase.com) - Open-source, privacy-first and simple analytics for mobile and desktop apps.
 - [Cabin](https://withcabin.com) - Privacy-first, carbon conscious web analytics.
+- [Ciphera Pulse](https://pulse.ciphera.net/) - Cookieless, GDPR-native alternative to Google Analytics from an EU company (Belgium) with Swiss/EU hosting; hosted SaaS with a free tier and an AGPL-3.0 frontend, though the backend is closed and it is not self-hostable.
 - [GoatCounter](https://www.goatcounter.com/) - Privacy aware, lightweight and open-source analytics platform.
 - [Matomo](https://matomo.org/) - Google Analytics alternative that protects your data and your customers' privacy.
 - [Nullitics](https://nullitics.com/) - Zero-effort open-source cheap analytics.


### PR DESCRIPTION
## Summary

Adds `Ciphera Pulse` to the `Analytics` section.

Ciphera Pulse is privacy-first, cookieless web analytics from Ciphera BV, an EU company based in Belgium, with data hosted in Switzerland/EU. No cookies means no cookie banner, and it is GDPR-native. It sits alongside its neighbours in this section (Cabin, Plausible, Umami) as a Google Analytics alternative.

I am affiliated with the project, so I have kept the entry objective and stated the drawbacks: the frontend is open source (AGPL-3.0) but the backend is closed, and there is no self-hosting option. Per the contributing guide, non-open-source services can be listed where there is a clear privacy stance, which I have tried to document below.

- Site: https://pulse.ciphera.net/
- Live demo: https://pulse.ciphera.net/demo
- Frontend source (AGPL-3.0): https://github.com/ciphera-net/pulse
- WordPress plugin: https://wordpress.org/plugins/pulse-analytics/

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents) — N/A, adding to the existing `Analytics` section
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed) — pulse.ciphera.net serves no Google/Facebook/etc. trackers; it uses its own Pulse analytics
- [x] Source or repo link is provided (frontend, AGPL-3.0)
- [x] License is stated (AGPL-3.0 frontend; backend closed)
- [x] Project is maintained