### PR TITLE
Adds Nutilz EXIF Remover to Photo Editing and Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1183,6 +1183,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [Nutilz EXIF Remover](https://nutilz.com/exif-remover) - Free browser-based tool that strips GPS, camera and other EXIF/XMP metadata from JPEG, PNG and WebP images. Processing happens entirely client-side via canvas; images are never uploaded to a server. Not open source.
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.


### PR DESCRIPTION
## Summary
Adds `Nutilz EXIF Remover` to the `Photo Editing and Management` section (Web subsection).

## Checklist
- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents) — n/a, no new section added
- [ ] Project has a clear privacy / own-your-data policy
- [ ] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [ ] Source or repo link is provided
- [ ] License is stated
- [x] Project is maintained

## Disclosure

I run nutilz.com, so this is a self-submission — flagging that up front per your affiliation-disclosure guideline.

Being upfront about why several boxes above are unchecked rather than glossing over them:

- **Not open source.** There's no public GitHub/Codeberg repo to link, so no license to state either.
- **The tool itself makes zero network calls.** I checked the page's client code and there's no `fetch`/XHR anywhere — the image never leaves the browser. EXIF/XMP detection and stripping both happen via Canvas, entirely client-side.
- **But the wider site does load Google Analytics** (gtag.js, sitewide, including on this page). So I can't honestly check the "no third-party trackers" box even though the tool's own image-processing path is fully local.

I think the client-side-only processing is a genuinely relevant data point for this list, but I understand the sitewide GA may be a disqualifier per your "no user-tracking" requirement, and I'd rather say so directly than have it come up in review. Happy to have this closed if it doesn't clear the bar — no hard feelings either way, and thanks for maintaining this list.