### PR TITLE
Add ScribeDog to Notes and Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [Notesnook](https://notesnook.com/) - Open source zero knowledge private note taking.
 - [Obsidian](https://obsidian.md) - Obsidian is the private and flexible note‑taking app. Closed source but has no trackers (website / apps) and E2EE sync. 
 - [Quillpad](https://quillpad.github.io/) - Take beautiful markdown notes and stay organized with task lists. Fork of Quillnote.
+- [ScribeDog](https://github.com/snooky234/scribedog) - WYSIWYG markdown editor whose AI writing assistance and voice dictation run entirely on your machine via Ollama, Jan.ai, LM Studio and whisper.cpp; no account, no telemetry, notes stay plain `.md` files. MIT, Windows and Linux.
 - [SiYuan](https://github.com/siyuan-note/siyuan) - A local-first personal knowledge management system.
 - [Standard Notes](https://standardnotes.org/) - A free, open-source, and completely encrypted notes app.
 - [TinyList](https://tinylist.app/) - Create and share notes and checklists, without sacrificing your privacy.


### PR DESCRIPTION
## Summary

Adds `ScribeDog` to the `Notes and Tasks` section.

ScribeDog is a WYSIWYG markdown editor built around the idea that AI writing assistance should not require handing your text to anyone. Both the AI features (rewrite, extend, translate, grammar check) and the voice dictation run locally — through Ollama, Jan.ai or LM Studio for text, and whisper.cpp for speech — so the app is fully usable offline. Cloud providers are supported but strictly opt-in with your own API key, which is stored in the OS credential store rather than on disk.

There is no account, no telemetry and no analytics. The only automatic network request is an optional update check against GitHub, which can be disabled in the settings. Notes are stored as plain `.md` files in a folder you choose, and Tauri's filesystem capabilities are scoped to that folder rather than the whole disk.

Placed alphabetically between `Quillpad` and `SiYuan`.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents) — n/a, existing section
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not
