### PR TITLE
Add Mako to Android Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Third-party launchers found on the play store. They may contain ads/trackers and
 - [Pie Launcher](https://github.com/markusfisch/PieLauncher) - Android home screen launcher that uses a dynamic pie menu instead of fixed positioned icons.
 - [Bliss Launcher](https://f-droid.org/en/packages/foundation.e.blisslauncher/) - The default launcher of the /e/ Android-based OS.
 It allows users to easily create and browse group of apps and it displays notification badges on app icons.
+- [Mako](https://f-droid.org/app/com.rama.mako) - Mako is a minimal, FOSS, privacy-first Android launcher designed for focus, speed, and simplicity.
 
 [Back to top 🔝](#contents)
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Third-party launchers found on the play store. They may contain ads/trackers and
 - [Pie Launcher](https://github.com/markusfisch/PieLauncher) - Android home screen launcher that uses a dynamic pie menu instead of fixed positioned icons.
 - [Bliss Launcher](https://f-droid.org/en/packages/foundation.e.blisslauncher/) - The default launcher of the /e/ Android-based OS.
 It allows users to easily create and browse group of apps and it displays notification badges on app icons.
-- [Mako](https://f-droid.org/app/com.rama.mako) - Mako is a minimal, FOSS, privacy-first Android launcher designed for focus, speed, and simplicity.
+- [Mako](https://github.com/rama-io/mako) - Mako is a minimal, FOSS, privacy-first Android launcher designed for focus, speed, and simplicity.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
## Summary

Adds `Mako` to the `Android Launcher` section under `Bliss Launcher`.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents)
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed)
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not