### PR TITLE
Add Compartment to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 	- [Text To Speech](#text-to-speech)
  	- [Speech To Text](#speech-to-text)
 	- [Image Generation](#image-generation)
+	- [Agent Memory](#agent-memory)
 - [Bookmarking](#bookmarking)
     - [Book and web annotations](#book-and-web-annotationshighlights-management)
 - [Captchas](#captchas)
@@ -305,6 +306,10 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Stable Diffusion Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) - A browser interface for Stable Diffusion and other models.
 - [InvokeAI](https://github.com/invoke-ai/InvokeAI) - Generate and create stunning visual media using the latest AI-driven technologies locally.
 - [SwarmUI](https://github.com/mcmonkeyprojects/SwarmUI) - Local web interface for Stable Diffusion and other diffusion models, built on a ComfyUI backend. MIT licensed.
+
+#### Agent Memory
+
+- [engRAM](https://github.com/MaxFreedomPollard/engRAM) - Fully offline, encrypted-at-rest vector memory for AI agents, usable over MCP or CLI. Embeddings and records are AEAD-encrypted with per-record crypto-shred deletion; no cloud and no API keys. Python, MIT licensed.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds **Compartment** to the Artificial Intelligence section.

Compartment is a fully offline, encrypted-at-rest vector memory for AI agents (usable over MCP or from the CLI): embeddings and records are AEAD-encrypted, deletion is a per-record crypto-shred, and it runs with no cloud and no API keys — a good fit for a privacy list. Python, MIT.

None of the existing AI subsections (ChatGPT / AI Coding / TTS / STT / Image Generation) fit an agent-memory tool, so I added a small **Agent Memory** subsection and a matching Contents entry. Happy to move it under a different heading if you'd prefer.

Repo: https://github.com/MaxFreedomPollard/Compartment

_Note: the project was renamed from **engRAM** to **Compartment** while this PR was open; the entry has been updated to the new name and repo URL. No other changes._
