### PR TITLE
Add Logue to Notes and Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ These providers offer apps and services filled with data trackers. Also, most of
 - [HedgeDoc](https://hedgedoc.org/) - Formerly CodiMD (community). An awesome platform to write and share markdown.
 - [Joplin](https://github.com/laurent22/joplin) - Note taking and to-do application with synchronisation and encryption capabilities.
 - [Logseq](https://logseq.com/) - A privacy-first alternative to WorkFlowy.
+- [Logue](https://github.com/bitwize-ai/Logue) - Privacy-first AI meeting notes and writing assistant for macOS. On-device transcription and speaker diarization; by default nothing leaves your Mac. Open source.
 - [Memos](https://github.com/usememos/memos) - An open-source, self-hosted memo hub with knowledge management and socialization. 
 - [Nextcloud Notes](https://github.com/nextcloud/notes/) - The Notes app is a distraction free notes taking app for Nextcloud.
 	- [Nextcloud Notes app](https://github.com/stefan-niedermann/nextcloud-notes) - An android client for Nextcloud Notes.


### PR DESCRIPTION
Adds **[Logue](https://github.com/bitwize-ai/Logue)** to **Notes and Tasks → Instead use** (placed alphabetically).

Logue is a free, open-source, privacy-first AI meeting-notes and writing app for macOS. All transcription, speaker diarization, and AI inference run **on-device** on Apple Silicon — by default nothing leaves the Mac and there's no account/telemetry. Fits the list's privacy-respecting-alternative criteria (a local alternative to cloud meeting-notes services).