### PR TITLE
Add Vincent to Design Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Apps such as Tinder collect and sell your personal intimate information. Tinder 
 - [GIMP](https://www.gimp.org/) - A free and open-source raster graphics editor used for image manipulation (retouching) and image editing, free-form drawing, transcoding between different image file formats, and more specialized tasks. It is not designed to be used for drawing, though some artists and creators have used it in this way.
 - [Inkscape](https://inkscape.org/) - A free and open-source vector graphics editor for GNU/Linux, Windows and macOS. It offers a rich set of features and is widely used for both artistic and technical illustrations such as cartoons, clip art, logos, typography, diagramming and flowcharting. 
 - [Krita](https://krita.org/) - A free and open-source raster graphics editor designed primarily for digital art and 2D animation.
+- [Vincent](https://github.com/iisacc-Justmoong/Vincent) - A local-first raster drawing and handwriting app for Windows that stores working files on the user's computer and has no accounts, telemetry, advertising, or automatic updates. AGPL-3.0 licensed.
 - [Excalidraw](https://github.com/excalidraw/excalidraw) - Virtual whiteboard for sketching hand-drawn like diagrams.
 
 ### Figma


### PR DESCRIPTION
## Summary

Adds `Vincent` to the `Design Tools / Photoshop / Illustrator` section.

Vincent is a Windows raster drawing and handwriting application whose working files stay on the user's computer. The application has no account system, telemetry, analytics, advertising, or automatic updater. Its complete source is public under AGPL-3.0.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] New section is added to the Table of Contents (Contents) — not applicable; existing section used
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers (only analytics from the Analytics section allowed) — entry links directly to the source repository
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained, or flagged with 💀 if not

Validation performed: the repository link returns HTTP 200, the diff passes `git diff --check`, and `scripts/health_report.py --diff-base upstream/main` reports no open-source concerns.