### PR TITLE
Add AI Writing Detection subsection — a detector that runs in the browser instead of uploading your documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 	- [Text To Speech](#text-to-speech)
  	- [Speech To Text](#speech-to-text)
 	- [Image Generation](#image-generation)
+	- [AI Writing Detection](#ai-writing-detection)
 - [Bookmarking](#bookmarking)
     - [Book and web annotations](#book-and-web-annotationshighlights-management)
 - [Captchas](#captchas)
@@ -305,6 +306,10 @@ When using cloud-based AI services, the data you input is often collected and st
 - [Stable Diffusion Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) - A browser interface for Stable Diffusion and other models.
 - [InvokeAI](https://github.com/invoke-ai/InvokeAI) - Generate and create stunning visual media using the latest AI-driven technologies locally.
 - [SwarmUI](https://github.com/mcmonkeyprojects/SwarmUI) - Local web interface for Stable Diffusion and other diffusion models, built on a ComfyUI backend. MIT licensed.
+
+#### AI Writing Detection
+
+- [Signs of AI Writing](https://github.com/peopleworks/SignsofAI) - Flags the tells of AI-generated text in English and Spanish and shows the evidence behind each one — overused vocabulary, rhetorical crutches, syntactic patterns and sentence rhythm — instead of a black-box percentage. Runs entirely in your browser through WebAssembly: documents are never uploaded, there is no account and the site has no tracking. It also compares documents against each other to surface copied or paraphrased passages. MIT licensed.
 
 [Back to top 🔝](#contents)
 


### PR DESCRIPTION
Adds a small **AI Writing Detection** subsection under *Artificial Intelligence*, with one entry: [Signs of AI Writing](https://github.com/peopleworks/SignsofAI). ToC updated. 5 lines total.

### Why it belongs on a privacy list

AI-detection is a category where the privacy problem is severe and rarely discussed. Every mainstream option — GPTZero, Originality.ai, Copyleaks, Turnitin — requires you to **upload the document**: student essays, unpublished manuscripts, internal drafts, medical or legal writing. Turnitin famously retains submissions in a permanent comparison database. There is currently no entry on this list for people who need this and don't want to hand their text to a third party.

This one runs **entirely in the browser** (Blazor WebAssembly): the analysis happens on the user's own device, the document is never uploaded, there is no account, and no request leaves the page for the four analysis features.

### Against the contribution requirements

- **Clear privacy-oriented policy** — client-side by design, not by promise: the app is a static site, so there is no server that *could* receive the text. Two clearly-labelled optional features (perplexity scoring and cross-language paraphrase matching) do call an API; their descriptions state that before use, and they are opt-in and separate from the four local ones.
- **No user tracking on the project website** — the demo is a static GitHub Pages build with no analytics, no tag manager, no third-party scripts.
- **Open source** — MIT, .NET 10 / Blazor WebAssembly. The rule packs are plain JSON you can read and edit.

### What it actually does

Rather than returning "87% AI", it highlights the specific tells it found — overused vocabulary, rhetorical crutches, syntactic patterns, and the statistical rhythm of sentence lengths — and suggests a fix for each. It works in **English and Spanish** (the Spanish rule pack is derived from scratch, not machine-translated). It also compares documents against each other and highlights the shared passages, including paraphrases across languages.

Demo: https://peopleworks.github.io/SignsofAI/ · Code: https://github.com/peopleworks/SignsofAI

Honest disclosure: it's a young project and I'm its author. Happy to reword the entry, drop the subsection and file it under an existing one, or add an ⛔ Avoid block listing the upload-based detectors — whatever fits the list's style best.
