### PR TITLE
Add Semaphore (browser image→ASCII, nothing uploaded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Google captchas use cookies to track users and rank their IPs.
 - [Fawkes](https://github.com/Shawn-Shan/fawkes) [💀](#icons) - privacy preserving tool against facial recognition systems.
   - [CloakMe](https://github.com/pluja/CloakMe) [💀](#icons) - Web interface for Fawkes algorithm.
 - [ImageScrubber](https://github.com/everestpipkin/image-scrubber) - A friendly browser-based tool for anonymizing photographs taken at protests ([hosted version provided by everestpipkin](https://everestpipkin.github.io/image-scrubber/)).
+- [Semaphore](https://semaphore.bobochang.cn/) ([source](https://github.com/can4hou6joeng4/Semaphore)) - Convert any image to ASCII art entirely in the browser. Nothing is uploaded; production CSP is `connect-src 'none'`. Free, open source (MIT), no account.
 
 ### Text
 - [Stegcloak](https://stegcloak.surge.sh/) - Hide secrets with invisible characters in plain text securely using passwords ([repo](https://github.com/kurolabs/stegcloak)).

--- a/README.md
+++ b/README.md
@@ -1183,6 +1183,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 ✅  **Instead use**
 #### Web
 - [miniPaint](https://github.com/viliusle/miniPaint) - Open Source alternative to Photopea. miniPaint operates directly in the browser. Nothing will be sent to any server. Everything stays in your browser.
+- [Semaphore](https://semaphore.bobochang.cn/tool) - MIT-licensed alternative to hosted image-to-ASCII converters that processes images entirely in the browser with no uploads or tracking; its production CSP uses `connect-src 'none'`. ([Source](https://github.com/can4hou6joeng4/Semaphore))
 
 #### Desktop
 - [GIMP](https://www.gimp.org/) - The Free & Open Source Image Editor.

--- a/README.md
+++ b/README.md
@@ -386,7 +386,6 @@ Google captchas use cookies to track users and rank their IPs.
 - [Fawkes](https://github.com/Shawn-Shan/fawkes) [💀](#icons) - privacy preserving tool against facial recognition systems.
   - [CloakMe](https://github.com/pluja/CloakMe) [💀](#icons) - Web interface for Fawkes algorithm.
 - [ImageScrubber](https://github.com/everestpipkin/image-scrubber) - A friendly browser-based tool for anonymizing photographs taken at protests ([hosted version provided by everestpipkin](https://everestpipkin.github.io/image-scrubber/)).
-- [Semaphore](https://semaphore.bobochang.cn/) ([source](https://github.com/can4hou6joeng4/Semaphore)) - Convert any image to ASCII art entirely in the browser. Nothing is uploaded; production CSP is `connect-src 'none'`. Free, open source (MIT), no account.
 
 ### Text
 - [Stegcloak](https://stegcloak.surge.sh/) - Hide secrets with invisible characters in plain text securely using passwords ([repo](https://github.com/kurolabs/stegcloak)).


### PR DESCRIPTION
## Summary

Adds Semaphore to the **Photo Editing and Management → Web** section.

Semaphore is a static, MIT-licensed alternative to hosted image-to-ASCII converters. Image processing stays in the browser, the site has no analytics or third-party runtime requests, and production enforces `connect-src 'none'`.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [x] No new section is added, so no Table of Contents change is needed
- [x] Project has a clear privacy / own-your-data policy
- [x] Project website loads no third-party trackers
- [x] Source or repo link is provided
- [x] License is stated
- [x] Project is maintained
