### PR TITLE
Add EmailOps email client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ No servers involved. Everything goes directly from one peer to the other peer. N
 - [🤖](#icons) [K9](https://k9mail.app/) - Open Source Email App for Android.
 
 #### Desktop
+- [EmailOps](https://github.com/emailops/emailops) - Email client with on-device AI: inbox chat, drafts and classification run through an embedded llama.cpp, so no message content is sent to a third-party model (Apache-2.0, macOS/Windows/Linux).
 - [Thunderbird](https://www.thunderbird.net) - A free customizable open source email client.
 
 ### Email Alias Services (Anonymous Forwarding)


### PR DESCRIPTION
Added EmailOps to the desktop email clients list in README.

## Summary

Adds `EmailOps` to the `Clients → Desktop` section, under Mail Services.

## Checklist

- [x] Entry uses the format `- [Name](url) - description.`
- [ ] New section is added to the Table of Contents (Contents) — n/a, no new section
- [x] Project has a clear privacy / own-your-data policy — https://getemailops.com/en/privacy/
- [x] Project website loads no third-party trackers — getemailops.com uses Umami, which this list allows under Analytics
- [x] Source or repo link is provided — https://github.com/emailops/emailops
- [x] License is stated — Apache-2.0
- [x] Project is maintained — 10 releases since May 2026, latest v0.6.6 on 14 Aug

## Why here

The privacy-relevant part is where the AI runs: inbox chat, draft generation and
classification all execute on-device through an embedded llama.cpp runtime, so message
content is never sent to a third-party model. Ollama and OpenRouter are opt-in and off
by default. Mail, attachments and the vector index live in a local SQLite database,
OAuth tokens go in the OS keychain, and the app ships no telemetry.
